### PR TITLE
enable the tf_prefix parameter

### DIFF
--- a/include/robot_state_publisher/joint_state_listener.h
+++ b/include/robot_state_publisher/joint_state_listener.h
@@ -64,6 +64,7 @@ private:
   void callbackJointState(const JointStateConstPtr& state);
   void callbackFixedJoint(const ros::TimerEvent& e);
 
+  std::string tf_prefix_;
   Duration publish_interval_;
   robot_state_publisher::RobotStatePublisher state_publisher_;
   Subscriber joint_state_sub_;

--- a/include/robot_state_publisher/robot_state_publisher.h
+++ b/include/robot_state_publisher/robot_state_publisher.h
@@ -73,8 +73,8 @@ public:
    * \param joint_positions A map of joint names and joint positions. 
    * \param time The time at which the joint positions were recorded
    */
-  void publishTransforms(const std::map<std::string, double>& joint_positions, const ros::Time& time);
-  void publishFixedTransforms();
+  void publishTransforms(const std::map<std::string, double>& joint_positions, const ros::Time& time, const std::string& tf_prefix);
+  void publishFixedTransforms(const std::string& tf_prefix);
 
 private:
   void addChildren(const KDL::SegmentMap::const_iterator segment);

--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -56,7 +56,10 @@ JointStateListener::JointStateListener(const KDL::Tree& tree)
   // set publish frequency
   double publish_freq;
   n_tilde.param("publish_frequency", publish_freq, 50.0);
-  n_tilde.param("tf_prefix", tf_prefix_, std::string(""));
+  // get the tf_prefix parameter from the closest namespace
+  std::string tf_prefix_key;
+  n_tilde.searchParam("tf_prefix", tf_prefix_key);
+  n_tilde.param(tf_prefix_key, tf_prefix_, std::string(""));
   publish_interval_ = ros::Duration(1.0/max(publish_freq,1.0));
 
   // subscribe to joint state

--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -56,8 +56,8 @@ JointStateListener::JointStateListener(const KDL::Tree& tree)
   // set publish frequency
   double publish_freq;
   n_tilde.param("publish_frequency", publish_freq, 50.0);
+  n_tilde.param("tf_prefix", tf_prefix_, std::string(""));
   publish_interval_ = ros::Duration(1.0/max(publish_freq,1.0));
-  
 
   // subscribe to joint state
   joint_state_sub_ = n.subscribe("joint_states", 1, &JointStateListener::callbackJointState, this);
@@ -74,7 +74,7 @@ JointStateListener::~JointStateListener()
 
 void JointStateListener::callbackFixedJoint(const ros::TimerEvent& e)
 {
-  state_publisher_.publishFixedTransforms();
+  state_publisher_.publishFixedTransforms(tf_prefix_);
 }
 
 void JointStateListener::callbackJointState(const JointStateConstPtr& state)
@@ -101,7 +101,7 @@ void JointStateListener::callbackJointState(const JointStateConstPtr& state)
     map<string, double> joint_positions;
     for (unsigned int i=0; i<state->name.size(); i++)
       joint_positions.insert(make_pair(state->name[i], state->position[i]));
-    state_publisher_.publishTransforms(joint_positions, state->header.stamp);
+    state_publisher_.publishTransforms(joint_positions, state->header.stamp, tf_prefix_);
 
     // store publish time in joint map
     for (unsigned int i=0; i<state->name.size(); i++)

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -75,7 +75,7 @@ namespace robot_state_publisher{
 
 
   // publish moving transforms
-  void RobotStatePublisher::publishTransforms(const map<string, double>& joint_positions, const Time& time)
+  void RobotStatePublisher::publishTransforms(const map<string, double>& joint_positions, const Time& time, const std::string& tf_prefix)
   {
     ROS_DEBUG("Publishing transforms for moving joints");
     std::vector<tf::StampedTransform> tf_transforms;
@@ -87,8 +87,8 @@ namespace robot_state_publisher{
       std::map<std::string, SegmentPair>::const_iterator seg = segments_.find(jnt->first);
       if (seg != segments_.end()){
         tf::transformKDLToTF(seg->second.segment.pose(jnt->second), tf_transform);    
-        tf_transform.frame_id_ = seg->second.root;
-        tf_transform.child_frame_id_ = seg->second.tip;
+        tf_transform.frame_id_ = tf::resolve(tf_prefix, seg->second.root);
+        tf_transform.child_frame_id_ = tf::resolve(tf_prefix, seg->second.tip);
         tf_transforms.push_back(tf_transform);
       }
     }
@@ -97,7 +97,7 @@ namespace robot_state_publisher{
 
 
   // publish fixed transforms
-  void RobotStatePublisher::publishFixedTransforms()
+  void RobotStatePublisher::publishFixedTransforms(const std::string& tf_prefix)
   {
     ROS_DEBUG("Publishing transforms for moving joints");
     std::vector<tf::StampedTransform> tf_transforms;
@@ -107,8 +107,8 @@ namespace robot_state_publisher{
     // loop over all fixed segments
     for (map<string, SegmentPair>::const_iterator seg=segments_fixed_.begin(); seg != segments_fixed_.end(); seg++){
       tf::transformKDLToTF(seg->second.segment.pose(0), tf_transform);    
-      tf_transform.frame_id_ = seg->second.root;
-      tf_transform.child_frame_id_ = seg->second.tip;
+      tf_transform.frame_id_ = tf::resolve(tf_prefix, seg->second.root);
+      tf_transform.child_frame_id_ = tf::resolve(tf_prefix, seg->second.tip);
       tf_transforms.push_back(tf_transform);
     }
     tf_broadcaster_.sendTransform(tf_transforms);


### PR DESCRIPTION
`tf_prefix` is being [deprecated](http://www.ros.org/wiki/hydro/Migration#tf2.2BAC8-Migration.Removal_of_support_for_tf_prefix) in ROS Hydro. I would still like to use the `tf_prefix` parameter http://www.ros.org/wiki/robot_state_publisher#Parameters to distinguish between different robots in multi-robot systems.

It seems that the robot_state_publisher code is not using either `tf::resolve` or reading in the `tf_prefix`, so I am a bit confused as to how this was was working pre-Hydro. I remember running some tests a few months ago that worked.

This patch reads the parameter explicitly and sets it using `tf::resolve`. Using this patch, I can run multiple robots in Gazebo without tf tree collisions.
