### PR TITLE
Update KDL SegmentMap interface to use shared pointers

### DIFF
--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -55,12 +55,12 @@ namespace robot_state_publisher{
   // add children to correct maps
   void RobotStatePublisher::addChildren(const KDL::SegmentMap::const_iterator segment)
   {
-    const std::string& root = segment->second.segment.getName();
+    const std::string& root = GetTreeElementSegment(segment->second).getName();
 
-    const std::vector<KDL::SegmentMap::const_iterator>& children = segment->second.children;
+    const std::vector<KDL::SegmentMap::const_iterator>& children = GetTreeElementChildren(segment->second);
     for (unsigned int i=0; i<children.size(); i++){
-      const KDL::Segment& child = children[i]->second.segment;
-      SegmentPair s(children[i]->second.segment, root, child.getName());
+      const KDL::Segment& child = GetTreeElementSegment(children[i]->second);
+      SegmentPair s(GetTreeElementSegment(children[i]->second), root, child.getName());
       if (child.getJoint().getType() == KDL::Joint::None){
         segments_fixed_.insert(make_pair(child.getJoint().getName(), s));
         ROS_DEBUG("Adding fixed segment from %s to %s", root.c_str(), child.getName().c_str());


### PR DESCRIPTION
This is a dependent change for the orocos KDL API modification discussed in: https://github.com/orocos/orocos_kinematics_dynamics/pull/4

To summarize the KDL API used incomplete type definitions in STL containers, which is undefined behaviour according the c++ standard. As it was, GCC / libstc++ handles this behaviour with problems; however, on systems with clang/libc++ using incomplete type definitions in STL containers results in compilation errors. Instead a solution involving shared pointers has been proposed. More rational the change is discussed in the upstream pull request.

The upstream pull request is necessary for this change to be merged.
