### PR TITLE
adds orocos_kdl dependency and linking rules (fixes #8)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 project(robot_state_publisher)
 
 find_package(Eigen REQUIRED)
-
+find_package(orocos_kdl REQUIRED) 
 find_package(catkin REQUIRED
   COMPONENTS roscpp rosconsole rostime tf tf_conversions kdl_parser
 )
@@ -10,23 +10,24 @@ find_package(catkin REQUIRED
 catkin_package(
   LIBRARIES ${PROJECT_NAME}_solver
   INCLUDE_DIRS include
-  DEPENDS roscpp rosconsole rostime tf tf_conversions kdl_parser
+  DEPENDS roscpp rosconsole rostime tf tf_conversions kdl_parser orocos_kdl
 )
 
 include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS})
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${orocos_kdl_INCLUDE_DIRS})
+link_directories(${orocos_kdl_LIBRARY_DIRS})
 
 add_library(${PROJECT_NAME}_solver
   src/robot_state_publisher.cpp src/treefksolverposfull_recursive.cpp
 )
-target_link_libraries(${PROJECT_NAME}_solver ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}_solver ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES})
 
 add_executable(${PROJECT_NAME} src/joint_state_listener.cpp)
-target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME}_solver log4cxx)
+target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME}_solver log4cxx ${orocos_kdl_LIBRARIES})
 
 # compile the same executable using the old name as well
 add_executable(state_publisher src/joint_state_listener.cpp)
-target_link_libraries(state_publisher ${PROJECT_NAME}_solver log4cxx)
+target_link_libraries(state_publisher ${PROJECT_NAME}_solver log4cxx ${orocos_kdl_LIBRARIES})
 
 # CATKIN has no ROS test for now. Disabling
 

--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
 
   <build_depend>eigen</build_depend>
   <build_depend>kdl_parser</build_depend> 
+  <build_depend>orocos_kdl</build_depend>
   <build_depend>rosconsole</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rostime</build_depend>
@@ -32,6 +33,7 @@
   <run_depend>catkin</run_depend>
   <run_depend>eigen</run_depend>
   <run_depend>kdl_parser</run_depend> 
+  <run_depend>orocos_kdl</run_depend>
   <run_depend>rosconsole</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rostime</run_depend>


### PR DESCRIPTION
With these changes I'm able again to compile and run the robot_state_publisher again.

I'm a bit confused about the completely missing orocos_kdl dependency though. I wonder how it ever was possible to compile this package at all?! The library and both executables all depend on KDL directly.

So, since it compiled before, I'm not 100% sure my proposed changes are correct/the best way. So far this was the approach I took for all my packages involving KDL. If there is a better solution, please let me know.
