### PR TITLE
link to orocos_kdl explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(robot_state_publisher)
 
 find_package(Eigen REQUIRED)
 
+find_package(orocos_kdl REQUIRED)
+
 find_package(catkin REQUIRED
   COMPONENTS roscpp rosconsole rostime tf tf_conversions kdl_parser
 )
@@ -22,11 +24,11 @@ add_library(${PROJECT_NAME}_solver
 target_link_libraries(${PROJECT_NAME}_solver ${catkin_LIBRARIES})
 
 add_executable(${PROJECT_NAME} src/joint_state_listener.cpp)
-target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME}_solver log4cxx)
+target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME}_solver ${orocos_kdl_LIBRARIES} log4cxx)
 
 # compile the same executable using the old name as well
 add_executable(state_publisher src/joint_state_listener.cpp)
-target_link_libraries(state_publisher ${PROJECT_NAME}_solver log4cxx)
+target_link_libraries(state_publisher ${PROJECT_NAME}_solver ${orocos_kdl_LIBRARIES} log4cxx)
 
 # CATKIN has no ROS test for now. Disabling
 


### PR DESCRIPTION
This fixes the following error:

Linking CXX executable
$HOME/ros/hydro/wet-ws/devel/lib/robot_state_publisher/state_publisher
/usr/bin/ld:
CMakeFiles/robot_state_publisher.dir/src/joint_state_listener.cpp.o: undefined
reference to symbol '_ZN3KDL7SegmentD1Ev'
$HOME/ros/hydro/wet/lib/liborocos-kdl.so.1.2: error adding symbols: DSO
missing from command line collect2: error: ld returned 1 exit status
