### PR TITLE
get rid of argv[0] debug output on startup

### DIFF
--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -137,7 +137,6 @@ int main(int argc, char** argv)
   // Initialize ros
   ros::init(argc, argv, "robot_state_publisher");
   NodeHandle node;
-  std::cout <<argv[0] << std::endl;
 
   ///////////////////////////////////////// begin deprecation warning
   std::string exe_name = argv[0];


### PR DESCRIPTION
`robot_state_publisher` prints `argv[0]` on startup, which is probably a leftover debug statement. Simply remove it. We have enough log clutter as it is ;-)
