### PR TITLE
add option for setting namespace as tf_prefix automatically

### DIFF
--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -56,10 +56,23 @@ JointStateListener::JointStateListener(const KDL::Tree& tree, const MimicMap& m)
   // set publish frequency
   double publish_freq;
   n_tilde.param("publish_frequency", publish_freq, 50.0);
-  // get the tf_prefix parameter from the closest namespace
-  std::string tf_prefix_key;
-  n_tilde.searchParam("tf_prefix", tf_prefix_key);
-  n_tilde.param(tf_prefix_key, tf_prefix_, std::string(""));
+
+  bool getns;
+  n_tilde.param<bool>("ns_tf_prefix", getns, false);
+
+  /*get current namespace as prefix for tf*/
+  if(getns)
+  {
+	  tf_prefix_=n.getNamespace();
+  }/*tf_prefix behavior*/
+  else
+  {
+	  // get the tf_prefix parameter from the closest namespace
+	  std::string tf_prefix_key;
+	  n_tilde.searchParam("tf_prefix", tf_prefix_key);
+	  n_tilde.param(tf_prefix_key, tf_prefix_, std::string(""));
+  }
+
   publish_interval_ = ros::Duration(1.0/max(publish_freq,1.0));
 
   // subscribe to joint state


### PR DESCRIPTION
I would propose this to be able to set the tf_prefix automatically instead of supplying it in the launchfile manually.
According to http://wiki.ros.org/tf2/Migration#Removal_of_support_for_tf_prefix is deprecated, but currently I do not see another approach for having multiple robots.

Topics seem to do this automatically but only robot state publisher is somehow missing the feature to adapt to the namespace inside a group automatically.

I am trying to get my launchfile a bit more clean that I can put only one launchfile and just call it in multiple groups to achieve the same result. But robot state publisher is preventing this by not adapting the namespace automatically. Or maybe I am missing an option in string supplied to tf_prefix, if so, just tell me and forget about this.

Actually a namespace environment variable in launchfile could also do the same trick, but  there seems to be none available, if there is a way to get the current namespace into a parameter, please tell me, then this would also get obsolete.

I got only one way around this. putting the namespace into an argument. By default it would be ns="/" so it works with both groups and robot state. The disadvantage is that you have to have a group inside the launchfile itself, that wouldn't be the case with this little change.

I also found out that removing  a leading "/" is not necessary, it is automatically done by the following functions.

Now tell me what you think, or how it is supposed to be done.

Regards,

Christian
