### PR TITLE
Issue 29: reload robot_model via Trigger-Service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,9 @@ project(robot_state_publisher)
 
 find_package(orocos_kdl REQUIRED) 
 find_package(catkin REQUIRED
-  COMPONENTS roscpp rosconsole rostime tf tf_conversions kdl_parser cmake_modules std_srvs
+  COMPONENTS roscpp rosconsole rostime tf tf_conversions kdl_parser cmake_modules std_srvs roslint
 )
+
 find_package(Eigen REQUIRED)
 
 catkin_package(
@@ -12,6 +13,8 @@ catkin_package(
   INCLUDE_DIRS include
   DEPENDS roscpp rosconsole rostime tf tf_conversions kdl_parser orocos_kdl
 )
+
+roslint_cpp()
 
 include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS})
 include_directories(include ${catkin_INCLUDE_DIRS} ${orocos_kdl_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(robot_state_publisher)
 
 find_package(orocos_kdl REQUIRED) 
 find_package(catkin REQUIRED
-  COMPONENTS roscpp rosconsole rostime tf tf_conversions kdl_parser cmake_modules
+  COMPONENTS roscpp rosconsole rostime tf tf_conversions kdl_parser cmake_modules std_srvs
 )
 find_package(Eigen REQUIRED)
 

--- a/include/robot_state_publisher/joint_state_listener.h
+++ b/include/robot_state_publisher/joint_state_listener.h
@@ -34,8 +34,8 @@
 
 /* Author: Wim Meeussen */
 
-#ifndef JOINT_STATE_LISTENER_H
-#define JOINT_STATE_LISTENER_H
+#ifndef ROBOT_STATE_PUBLISHER_JOINT_STATE_LISTENER_H
+#define ROBOT_STATE_PUBLISHER_JOINT_STATE_LISTENER_H
 
 #include <urdf/model.h>
 #include <kdl/tree.hpp>
@@ -96,4 +96,4 @@ private:
 }  // namespace robot_state_publisher
 
 
-#endif  // JOINT_STATE_LISTENER_H
+#endif  // ROBOT_STATE_PUBLISHER_JOINT_STATE_LISTENER_H

--- a/include/robot_state_publisher/joint_state_listener.h
+++ b/include/robot_state_publisher/joint_state_listener.h
@@ -42,6 +42,7 @@
 #include <ros/ros.h>
 #include <sensor_msgs/JointState.h>
 #include "robot_state_publisher/robot_state_publisher.h"
+#include <std_srvs/Trigger.h>
 
 using namespace std;
 using namespace ros;
@@ -59,18 +60,29 @@ public:
    */
   JointStateListener(const KDL::Tree& tree, const MimicMap& m);
 
-  /// Destructor
+  ros::ServiceServer reload_server;
+
   ~JointStateListener();
 
 private:
+
+  /// Callback for reload-Service
+  bool reload_robot_model_cb(std_srvs::Trigger::Request& req, std_srvs::Trigger::Response& res);
+
+  bool reload_robot_model(std::string& error_msg);
+
+
   void callbackJointState(const JointStateConstPtr& state);
   void callbackFixedJoint(const ros::TimerEvent& e);
+
+  /// used as mutex
+  bool update_ongoing;
 
   std::string tf_prefix_;
   Duration publish_interval_;
   robot_state_publisher::RobotStatePublisher state_publisher_;
   Subscriber joint_state_sub_;
-  ros::Timer timer_;
+  ros::Timer pub_fixed_trafos_timer_;
   ros::Time last_callback_time_;
   std::map<std::string, ros::Time> last_publish_time_;
   MimicMap mimic_;

--- a/include/robot_state_publisher/joint_state_listener.h
+++ b/include/robot_state_publisher/joint_state_listener.h
@@ -45,6 +45,7 @@
 #include <std_srvs/Trigger.h>
 #include <map>
 #include <string>
+#include <boost/thread/mutex.hpp>
 
 using std::map;
 using std::string;
@@ -81,14 +82,14 @@ private:
   void callbackJointState(const JointStateConstPtr& state);
   void callbackFixedJoint(const ros::TimerEvent& e);
 
-  /// used as mutex
-  bool update_ongoing;
+
+  boost::mutex update_ongoing;
 
   std::string tf_prefix_;
   Duration publish_interval_;
   robot_state_publisher::RobotStatePublisher state_publisher_;
   Subscriber joint_state_sub_;
-  ros::Timer pub_fixed_trafos_timer_;
+  ros::Timer pub_fixed_tf_timer_;
   ros::Time last_callback_time_;
   std::map<std::string, ros::Time> last_publish_time_;
   MimicMap mimic_;

--- a/include/robot_state_publisher/joint_state_listener.h
+++ b/include/robot_state_publisher/joint_state_listener.h
@@ -43,17 +43,24 @@
 #include <sensor_msgs/JointState.h>
 #include "robot_state_publisher/robot_state_publisher.h"
 #include <std_srvs/Trigger.h>
+#include <map>
+#include <string>
 
-using namespace std;
-using namespace ros;
-using namespace KDL;
+using std::map;
+using std::string;
+using std::max;
+
+using ros::Duration;
+using ros::Subscriber;
 
 typedef boost::shared_ptr<sensor_msgs::JointState const> JointStateConstPtr;
 typedef std::map<std::string, boost::shared_ptr<urdf::JointMimic> > MimicMap;
 
-namespace robot_state_publisher{
+namespace robot_state_publisher
+{
 
-class JointStateListener{
+class JointStateListener
+{
 public:
   /** Constructor
    * \param tree The kinematic model of a robot, represented by a KDL Tree
@@ -65,11 +72,10 @@ public:
   ~JointStateListener();
 
 private:
-
   /// Callback for reload-Service
   bool reload_robot_model_cb(std_srvs::Trigger::Request& req, std_srvs::Trigger::Response& res);
 
-  bool reload_robot_model(std::string& error_msg);
+  bool reload_robot_model(std::string* error_msg);
 
 
   void callbackJointState(const JointStateConstPtr& state);
@@ -86,9 +92,8 @@ private:
   ros::Time last_callback_time_;
   std::map<std::string, ros::Time> last_publish_time_;
   MimicMap mimic_;
-
 };
-}
+}  // namespace robot_state_publisher
 
 
-#endif
+#endif  // JOINT_STATE_LISTENER_H

--- a/include/robot_state_publisher/robot_state_publisher.h
+++ b/include/robot_state_publisher/robot_state_publisher.h
@@ -34,8 +34,8 @@
 
 /* Author: Wim Meeussen */
 
-#ifndef ROBOT_STATE_PUBLISHER_H
-#define ROBOT_STATE_PUBLISHER_H
+#ifndef ROBOT_STATE_PUBLISHER_ROBOT_STATE_PUBLISHER_H
+#define ROBOT_STATE_PUBLISHER_ROBOT_STATE_PUBLISHER_H
 
 #include <ros/ros.h>
 #include <boost/scoped_ptr.hpp>
@@ -56,7 +56,7 @@ class SegmentPair
 {
 public:
   SegmentPair(const KDL::Segment& p_segment, const std::string& p_root, const std::string& p_tip):
-    segment(p_segment), root(p_root), tip(p_tip){}
+    segment(p_segment), root(p_root), tip(p_tip) {}
 
   KDL::Segment segment;
   std::string root, tip;
@@ -67,15 +67,15 @@ class RobotStatePublisher
 {
 public:
   /** Constructor
-   * \param tree The kinematic model of a robot, represented by a KDL Tree 
+   * \param tree The kinematic model of a robot, represented by a KDL Tree
    */
   explicit RobotStatePublisher(const KDL::Tree& tree);
 
   /// Destructor
-  ~RobotStatePublisher(){}
+  ~RobotStatePublisher() {}
 
-  /** Publish transforms to tf 
-   * \param joint_positions A map of joint names and joint positions. 
+  /** Publish transforms to tf
+   * \param joint_positions A map of joint names and joint positions.
    * \param time The time at which the joint positions were recorded
    */
   void publishTransforms(const std::map<std::string, double>& joint_positions,
@@ -84,7 +84,7 @@ public:
   void publishFixedTransforms(const std::string& tf_prefix);
 
   /** Sets the robot model
-  * \param tree The kinematic model of a robot, represented by a KDL Tree 
+  * \param tree The kinematic model of a robot, represented by a KDL Tree
   */
   void updateTree(const KDL::Tree& tree);
 
@@ -102,4 +102,4 @@ private:
 
 }  // namespace robot_state_publisher
 
-#endif  // ROBOT_STATE_PUBLISHER_H
+#endif  // ROBOT_STATE_PUBLISHER_ROBOT_STATE_PUBLISHER_H

--- a/include/robot_state_publisher/robot_state_publisher.h
+++ b/include/robot_state_publisher/robot_state_publisher.h
@@ -46,8 +46,11 @@
 #include <kdl/frames.hpp>
 #include <kdl/segment.hpp>
 #include <kdl/tree.hpp>
+#include <map>
+#include <string>
 
-namespace robot_state_publisher{
+namespace robot_state_publisher
+{
 
 class SegmentPair
 {
@@ -66,7 +69,7 @@ public:
   /** Constructor
    * \param tree The kinematic model of a robot, represented by a KDL Tree 
    */
-  RobotStatePublisher(const KDL::Tree& tree);
+  explicit RobotStatePublisher(const KDL::Tree& tree);
 
   /// Destructor
   ~RobotStatePublisher(){}
@@ -75,7 +78,9 @@ public:
    * \param joint_positions A map of joint names and joint positions. 
    * \param time The time at which the joint positions were recorded
    */
-  void publishTransforms(const std::map<std::string, double>& joint_positions, const ros::Time& time, const std::string& tf_prefix);
+  void publishTransforms(const std::map<std::string, double>& joint_positions,
+                         const ros::Time& time, const std::string& tf_prefix);
+
   void publishFixedTransforms(const std::string& tf_prefix);
 
   /** Sets the robot model
@@ -83,14 +88,11 @@ public:
   */
   void updateTree(const KDL::Tree& tree);
 
-  void createTreeInfo(std::string& msg);
+  void createTreeInfo(std::string* msg);
 
 
 private:
-
-
   void addChildren(const KDL::SegmentMap::const_iterator segment);
-
 
   std::map<std::string, SegmentPair> segments_, segments_fixed_;
   tf::TransformBroadcaster tf_broadcaster_;
@@ -98,6 +100,6 @@ private:
 
 
 
-}
+}  // namespace robot_state_publisher
 
-#endif
+#endif  // ROBOT_STATE_PUBLISHER_H

--- a/include/robot_state_publisher/robot_state_publisher.h
+++ b/include/robot_state_publisher/robot_state_publisher.h
@@ -39,6 +39,8 @@
 
 #include <ros/ros.h>
 #include <boost/scoped_ptr.hpp>
+
+
 #include <tf/tf.h>
 #include <tf/transform_broadcaster.h>
 #include <kdl/frames.hpp>
@@ -67,7 +69,7 @@ public:
   RobotStatePublisher(const KDL::Tree& tree);
 
   /// Destructor
-  ~RobotStatePublisher(){};
+  ~RobotStatePublisher(){}
 
   /** Publish transforms to tf 
    * \param joint_positions A map of joint names and joint positions. 
@@ -76,7 +78,17 @@ public:
   void publishTransforms(const std::map<std::string, double>& joint_positions, const ros::Time& time, const std::string& tf_prefix);
   void publishFixedTransforms(const std::string& tf_prefix);
 
+  /** Sets the robot model
+  * \param tree The kinematic model of a robot, represented by a KDL Tree 
+  */
+  void updateTree(const KDL::Tree& tree);
+
+  void createTreeInfo(std::string& msg);
+
+
 private:
+
+
   void addChildren(const KDL::SegmentMap::const_iterator segment);
 
 

--- a/include/robot_state_publisher/treefksolverposfull_recursive.hpp
+++ b/include/robot_state_publisher/treefksolverposfull_recursive.hpp
@@ -27,7 +27,8 @@
 #include <tf/transform_datatypes.h>
 
 
-namespace KDL {
+namespace KDL
+{
 
 class TreeFkSolverPosFull_recursive
 
@@ -36,14 +37,14 @@ public:
   TreeFkSolverPosFull_recursive(const Tree& _tree);
   ~TreeFkSolverPosFull_recursive();
 
-  int JntToCart(const std::map<std::string, double>& q_in, std::map<std::string, tf::Stamped<Frame> >& p_out, bool flatten_tree=true);
+  int JntToCart(const std::map<std::string, double>& q_in, std::map<std::string, tf::Stamped<Frame> >& p_out, bool flatten_tree = true);
 
 private:
-  void addFrameToMap(const std::map<std::string, double>& q_in, 
-		     std::map<std::string, tf::Stamped<KDL::Frame> >& p_out,
-		     const tf::Stamped<KDL::Frame>& previous_frame,
-		     const SegmentMap::const_iterator this_segment,
-		     bool flatten_tree);
+  void addFrameToMap(const std::map<std::string, double>& q_in,
+                     std::map<std::string, tf::Stamped<KDL::Frame> >& p_out,
+                     const tf::Stamped<KDL::Frame>& previous_frame,
+                     const SegmentMap::const_iterator this_segment,
+                     bool flatten_tree);
 
   Tree tree;
 

--- a/package.xml
+++ b/package.xml
@@ -30,6 +30,7 @@
   <build_depend>tf</build_depend>
   <build_depend>tf_conversions</build_depend>
   <build_depend>cmake_modules</build_depend>
+  <build_depend>std_srvs</build_depend>
 
   <run_depend>catkin</run_depend>
   <run_depend>eigen</run_depend>
@@ -41,4 +42,6 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>tf_conversions</run_depend>
+  <run_depend>std_srvs</run_depend>
+
 </package>

--- a/package.xml
+++ b/package.xml
@@ -31,6 +31,7 @@
   <build_depend>tf_conversions</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>std_srvs</build_depend>
+  <build_depend>ros_lint</build_depend>
 
   <run_depend>catkin</run_depend>
   <run_depend>eigen</run_depend>

--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -47,125 +47,201 @@ using namespace ros;
 using namespace KDL;
 using namespace robot_state_publisher;
 
-JointStateListener::JointStateListener(const KDL::Tree& tree, const MimicMap& m)
-  : state_publisher_(tree), mimic_(m)
+JointStateListener::JointStateListener(const KDL::Tree& tree, const MimicMap& m):
+    update_ongoing(false),
+    state_publisher_(tree),
+    mimic_(m)
 {
-  ros::NodeHandle n_tilde("~");
-  ros::NodeHandle n;
 
-  // set publish frequency
-  double publish_freq;
-  n_tilde.param("publish_frequency", publish_freq, 50.0);
-  // get the tf_prefix parameter from the closest namespace
-  std::string tf_prefix_key;
-  n_tilde.searchParam("tf_prefix", tf_prefix_key);
-  n_tilde.param(tf_prefix_key, tf_prefix_, std::string(""));
-  publish_interval_ = ros::Duration(1.0/max(publish_freq,1.0));
+    ros::NodeHandle n_tilde("~");
+    ros::NodeHandle n;
 
-  // subscribe to joint state
-  joint_state_sub_ = n.subscribe("joint_states", 1, &JointStateListener::callbackJointState, this);
+    // set publish frequency
+    double publish_freq;
+    n_tilde.param("publish_frequency", publish_freq, 50.0);
 
-  // trigger to publish fixed joints
-  timer_ = n_tilde.createTimer(publish_interval_, &JointStateListener::callbackFixedJoint, this);
+    // get the tf_prefix parameter from the closest namespace
+    std::string tf_prefix_key;
+    n_tilde.searchParam("tf_prefix", tf_prefix_key);
+    n_tilde.param(tf_prefix_key, tf_prefix_, std::string(""));
+    publish_interval_ = ros::Duration(1.0/max(publish_freq,1.0));
 
-};
+    reload_server = n_tilde.advertiseService("reload_robot_model", &JointStateListener::reload_robot_model_cb, this);
+
+    // subscribe to joint state
+    joint_state_sub_ = n.subscribe("joint_states", 1, &JointStateListener::callbackJointState, this);
+
+    // trigger to publish fixed joints
+    pub_fixed_trafos_timer_ = n_tilde.createTimer(publish_interval_, &JointStateListener::callbackFixedJoint, this);
+    pub_fixed_trafos_timer_.start();
+}
 
 
-JointStateListener::~JointStateListener()
-{};
+
+bool loadTreeAndMimicMap(KDL::Tree & tree, MimicMap& mimic_map, std::string& err_msg){
+
+    // gets the location of the robot description on the parameter server
+    urdf::Model model;
+    bool found = model.initParam("robot_description");
+
+    if (!found){
+        err_msg = "Could not read urdf_model from parameter server";
+        return false;
+    }
+
+    if (!kdl_parser::treeFromUrdfModel(model, tree)){
+        err_msg = "Failed to extract kdl tree from xml robot description";
+        return false;
+    }
+
+
+    mimic_map.clear();
+    std::map< std::string, boost::shared_ptr< urdf::Joint > >::iterator it;
+    for(it = model.joints_.begin(); it != model.joints_.end(); it++){
+        if(it->second->mimic){
+            mimic_map.insert(make_pair(it->first, it->second->mimic));
+        }
+    }
+
+    return true;
+
+}
+
+bool JointStateListener::reload_robot_model(std::string& msg){
+
+    update_ongoing = true;
+
+    pub_fixed_trafos_timer_.stop(); /// make sure that state_publisher is not currently publishing
+    publish_interval_.sleep(); /// allow publishFixedTransforms to end
+
+
+    KDL::Tree tree;
+    mimic_.clear();
+
+    if (!loadTreeAndMimicMap(tree, mimic_, msg)){
+        ROS_ERROR("%s",msg.c_str());
+        return false;
+    }
+
+    /// if the update fails, both publishers (for fixed and non-fixed trafos) keep turned off so
+    /// that the failure is obvious and no one is working with the old model
+
+    state_publisher_.updateTree(tree);
+
+    state_publisher_.createTreeInfo(msg); /// create an info-string for the service caller
+
+    pub_fixed_trafos_timer_.start(); /// fixed transforms are published again
+
+    update_ongoing = false;
+
+    return true;
+}
+
+
+
+bool JointStateListener::reload_robot_model_cb(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res){
+    ROS_DEBUG("Reload of Robot model requested");
+    res.success = reload_robot_model(res.message);
+    return true;
+}
+
+JointStateListener::~JointStateListener(){}
 
 
 void JointStateListener::callbackFixedJoint(const ros::TimerEvent& e)
 {
-  state_publisher_.publishFixedTransforms(tf_prefix_);
+    state_publisher_.publishFixedTransforms(tf_prefix_);
 }
 
 void JointStateListener::callbackJointState(const JointStateConstPtr& state)
 {
-  if (state->name.size() != state->position.size()){
-    ROS_ERROR("Robot state publisher received an invalid joint state vector");
-    return;
-  }
 
-  // check if we moved backwards in time (e.g. when playing a bag file)
-  ros::Time now = ros::Time::now();
-  if(last_callback_time_ > now) {
-    // force re-publish of joint transforms
-    ROS_WARN("Moved backwards in time (probably because ROS clock was reset), re-publishing joint transforms!");
-    last_publish_time_.clear();
-  }
-  last_callback_time_ = now;
-
-  // determine least recently published joint
-  ros::Time last_published = now;
-  for (unsigned int i=0; i<state->name.size(); i++)
-  {
-    ros::Time t = last_publish_time_[state->name[i]];
-    last_published = (t < last_published) ? t : last_published;
-  }
-  // note: if a joint was seen for the first time,
-  //       then last_published is zero.
-
-
-  // check if we need to publish
-  if (state->header.stamp >= last_published + publish_interval_){
-    // get joint positions from state message
-    map<string, double> joint_positions;
-    for (unsigned int i=0; i<state->name.size(); i++)
-      joint_positions.insert(make_pair(state->name[i], state->position[i]));
-
-    for(MimicMap::iterator i = mimic_.begin(); i != mimic_.end(); i++){
-      if(joint_positions.find(i->second->joint_name) != joint_positions.end()){
-        double pos = joint_positions[i->second->joint_name] * i->second->multiplier + i->second->offset;
-        joint_positions.insert(make_pair(i->first, pos));
-      }
+    /// continue processing of state-msgs to not collect old msgs in queue
+    if (update_ongoing){
+        ROS_WARN_THROTTLE(1,"Skipping joing state while robot model is updated");
+        return;
     }
 
-    state_publisher_.publishTransforms(joint_positions, state->header.stamp, tf_prefix_);
 
-    // store publish time in joint map
+    if (state->name.size() != state->position.size()){
+        ROS_ERROR("Robot state publisher received an invalid joint state vector");
+        return;
+    }
+
+    // check if we moved backwards in time (e.g. when playing a bag file)
+    ros::Time now = ros::Time::now();
+    if(last_callback_time_ > now) {
+        // force re-publish of joint transforms
+        ROS_WARN("Moved backwards in time (probably because ROS clock was reset), re-publishing joint transforms!");
+        last_publish_time_.clear();
+    }
+    last_callback_time_ = now;
+
+    // determine least recently published joint
+    ros::Time last_published = now;
     for (unsigned int i=0; i<state->name.size(); i++)
-      last_publish_time_[state->name[i]] = state->header.stamp;
-  }
+    {
+        ros::Time t = last_publish_time_[state->name[i]];
+        last_published = (t < last_published) ? t : last_published;
+    }
+    // note: if a joint was seen for the first time,
+    //       then last_published is zero.
+
+
+    // check if we need to publish
+    if (state->header.stamp >= last_published + publish_interval_){
+        // get joint positions from state message
+        map<string, double> joint_positions;
+        for (unsigned int i=0; i<state->name.size(); i++)
+            joint_positions.insert(make_pair(state->name[i], state->position[i]));
+
+        for(MimicMap::iterator i = mimic_.begin(); i != mimic_.end(); i++){
+            if(joint_positions.find(i->second->joint_name) != joint_positions.end()){
+                double pos = joint_positions[i->second->joint_name] * i->second->multiplier + i->second->offset;
+                joint_positions.insert(make_pair(i->first, pos));
+            }
+        }
+
+        state_publisher_.publishTransforms(joint_positions, state->header.stamp, tf_prefix_);
+
+        // store publish time in joint map
+        for (unsigned int i=0; i<state->name.size(); i++)
+            last_publish_time_[state->name[i]] = state->header.stamp;
+    }
 }
+
+
+
+
 
 // ----------------------------------
 // ----- MAIN -----------------------
 // ----------------------------------
 int main(int argc, char** argv)
 {
-  // Initialize ros
-  ros::init(argc, argv, "robot_state_publisher");
-  NodeHandle node;
 
-  ///////////////////////////////////////// begin deprecation warning
-  std::string exe_name = argv[0];
-  std::size_t slash = exe_name.find_last_of("/");
-  if (slash != std::string::npos)
-    exe_name = exe_name.substr(slash + 1);
-  if (exe_name == "state_publisher")
-    ROS_WARN("The 'state_publisher' executable is deprecated. Please use 'robot_state_publisher' instead");
-  ///////////////////////////////////////// end deprecation warning
+    ros::init(argc, argv, "robot_state_publisher");
 
-  // gets the location of the robot description on the parameter server
-  urdf::Model model;
-  model.initParam("robot_description");
-  KDL::Tree tree;
-  if (!kdl_parser::treeFromUrdfModel(model, tree)){
-    ROS_ERROR("Failed to extract kdl tree from xml robot description");
-    return -1;
-  }
+    ///////////////////////////////////////// begin deprecation warning
+    std::string exe_name = argv[0];
+    std::size_t slash = exe_name.find_last_of("/");
+    if (slash != std::string::npos)
+        exe_name = exe_name.substr(slash + 1);
+    if (exe_name == "state_publisher")
+        ROS_WARN("The 'state_publisher' executable is deprecated. Please use 'robot_state_publisher' instead");
+    ///////////////////////////////////////// end deprecation warning
 
-  MimicMap mimic;
+    /// gets the location of the robot description on the parameter server
+    KDL::Tree tree;
+    MimicMap mimic;
+    std::string err_msg;
 
-  for(std::map< std::string, boost::shared_ptr< urdf::Joint > >::iterator i = model.joints_.begin(); i != model.joints_.end(); i++){
-    if(i->second->mimic){
-      mimic.insert(make_pair(i->first, i->second->mimic));
+    if (!loadTreeAndMimicMap(tree, mimic, err_msg)){
+        ROS_ERROR("%s",err_msg.c_str());
+        return -1;
     }
-  }
 
-  JointStateListener state_publisher(tree, mimic);
-  ros::spin();
-
-  return 0;
+    JointStateListener state_publisher(tree, mimic);
+    ros::spin();
+    return 0;
 }

--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -47,172 +47,182 @@
 using robot_state_publisher::JointStateListener;
 
 JointStateListener::JointStateListener(const KDL::Tree& tree, const MimicMap& m):
-    update_ongoing(false),
-    state_publisher_(tree),
-    mimic_(m)
+  update_ongoing(false),
+  state_publisher_(tree),
+  mimic_(m)
 {
-    ros::NodeHandle n_tilde("~");
-    ros::NodeHandle n;
+  ros::NodeHandle n_tilde("~");
+  ros::NodeHandle n;
 
-    // set publish frequency
-    double publish_freq;
-    n_tilde.param("publish_frequency", publish_freq, 50.0);
+  // set publish frequency
+  double publish_freq;
+  n_tilde.param("publish_frequency", publish_freq, 50.0);
 
-    // get the tf_prefix parameter from the closest namespace
-    std::string tf_prefix_key;
-    n_tilde.searchParam("tf_prefix", tf_prefix_key);
-    n_tilde.param(tf_prefix_key, tf_prefix_, std::string(""));
-    publish_interval_ = ros::Duration(1.0/max(publish_freq, 1.0));
+  // get the tf_prefix parameter from the closest namespace
+  std::string tf_prefix_key;
+  n_tilde.searchParam("tf_prefix", tf_prefix_key);
+  n_tilde.param(tf_prefix_key, tf_prefix_, std::string(""));
+  publish_interval_ = ros::Duration(1.0 / max(publish_freq, 1.0));
 
-    reload_server = n_tilde.advertiseService("reload_robot_model", &JointStateListener::reload_robot_model_cb, this);
 
-    // subscribe to joint state
-    joint_state_sub_ = n.subscribe("joint_states", 1, &JointStateListener::callbackJointState, this);
+  /// only offer reload_service on request
+  bool with_reload;
+  n_tilde.param("with_reload_service", with_reload, false);
+  if (with_reload)
+    {
+      reload_server = n_tilde.advertiseService("reload_robot_model", &JointStateListener::reload_robot_model_cb, this);
+    }
 
-    // trigger to publish fixed joints
-    pub_fixed_trafos_timer_ = n_tilde.createTimer(publish_interval_, &JointStateListener::callbackFixedJoint, this);
-    pub_fixed_trafos_timer_.start();
+
+  // subscribe to joint state
+  joint_state_sub_ = n.subscribe("joint_states", 1, &JointStateListener::callbackJointState, this);
+
+  // trigger to publish fixed joints
+  pub_fixed_trafos_timer_ = n_tilde.createTimer(publish_interval_, &JointStateListener::callbackFixedJoint, this);
+  pub_fixed_trafos_timer_.start();
 }
 
 
 
 bool loadTreeAndMimicMap(KDL::Tree  tree, MimicMap *mimic_map, std::string *err_msg)
 {
-    // gets the location of the robot description on the parameter server
-    urdf::Model model;
-    bool found = model.initParam("robot_description");
+  // gets the location of the robot description on the parameter server
+  urdf::Model model;
+  bool found = model.initParam("robot_description");
 
-    if (!found)
+  if (!found)
     {
-        *err_msg = "Could not read urdf_model from parameter server";
-        return false;
+      *err_msg = "Could not read urdf_model from parameter server";
+      return false;
     }
 
-    if (!kdl_parser::treeFromUrdfModel(model, tree))
+  if (!kdl_parser::treeFromUrdfModel(model, tree))
     {
-        *err_msg = "Failed to extract kdl tree from xml robot description";
-        return false;
+      *err_msg = "Failed to extract kdl tree from xml robot description";
+      return false;
     }
 
 
-    mimic_map->clear();
-    std::map< std::string, boost::shared_ptr< urdf::Joint > >::iterator it;
-    for (it = model.joints_.begin(); it != model.joints_.end(); it++)
+  mimic_map->clear();
+  std::map< std::string, boost::shared_ptr< urdf::Joint > >::iterator it;
+  for (it = model.joints_.begin(); it != model.joints_.end(); it++)
     {
-        if (it->second->mimic)
+      if (it->second->mimic)
         {
-            mimic_map->insert(make_pair(it->first, it->second->mimic));
+          mimic_map->insert(make_pair(it->first, it->second->mimic));
         }
     }
 
-    return true;
+  return true;
 }
 
 bool JointStateListener::reload_robot_model(std::string* msg)
 {
-    update_ongoing = true;
+  update_ongoing = true;
 
-    pub_fixed_trafos_timer_.stop();  /// make sure that state_publisher is not currently publishing
-    publish_interval_.sleep();       /// allow publishFixedTransforms to end
+  pub_fixed_trafos_timer_.stop();  /// make sure that state_publisher is not currently publishing
+  publish_interval_.sleep();       /// allow publishFixedTransforms to end
 
 
-    KDL::Tree tree;
-    mimic_.clear();
+  KDL::Tree tree;
+  mimic_.clear();
 
-    if (!loadTreeAndMimicMap(tree, &mimic_, msg))
+  if (!loadTreeAndMimicMap(tree, &mimic_, msg))
     {
-        ROS_ERROR("%s", msg->c_str());
-        return false;
+      ROS_ERROR("%s", msg->c_str());
+      return false;
     }
 
-    /// if the update fails, both publishers (for fixed and non-fixed trafos) keep turned off so
-    /// that the failure is obvious and no one is working with the old model
+  /// if the update fails, both publishers (for fixed and non-fixed trafos) keep turned off so
+  /// that the failure is obvious and no one is working with the old model
 
-    state_publisher_.updateTree(tree);
-    state_publisher_.createTreeInfo(msg);  /// create an info-string for the service caller
-    pub_fixed_trafos_timer_.start();        /// fixed transforms are published again
+  state_publisher_.updateTree(tree);
+  state_publisher_.createTreeInfo(msg);  /// create an info-string for the service caller
+  pub_fixed_trafos_timer_.start();        /// fixed transforms are published again
 
-    update_ongoing = false;
+  update_ongoing = false;
 
-    return true;
+  return true;
 }
 
 
 
 bool JointStateListener::reload_robot_model_cb(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res)
 {
-    ROS_DEBUG("Reload of Robot model requested");
-    res.success = reload_robot_model(&res.message);
-    return true;
+  ROS_DEBUG("Reload of Robot model requested");
+  res.success = reload_robot_model(&res.message);
+  return true;
 }
 
-JointStateListener::~JointStateListener(){}
+JointStateListener::~JointStateListener() {}
 
 
 void JointStateListener::callbackFixedJoint(const ros::TimerEvent& e)
 {
-    state_publisher_.publishFixedTransforms(tf_prefix_);
+  state_publisher_.publishFixedTransforms(tf_prefix_);
 }
 
 void JointStateListener::callbackJointState(const JointStateConstPtr& state)
 {
-    /// continue processing of state-msgs to not collect old msgs in queue
-    if (update_ongoing)
+  /// continue processing of state-msgs to not collect old msgs in queue
+  if (update_ongoing)
     {
-        ROS_WARN_THROTTLE(1, "Skipping joing state while robot model is updated");
-        return;
+      ROS_WARN_THROTTLE(1, "Skipping joing state while robot model is updated");
+      return;
     }
 
 
-    if (state->name.size() != state->position.size()){
-        ROS_ERROR("Robot state publisher received an invalid joint state vector");
-        return;
+  if (state->name.size() != state->position.size())
+    {
+      ROS_ERROR("Robot state publisher received an invalid joint state vector");
+      return;
     }
 
-    // check if we moved backwards in time (e.g. when playing a bag file)
-    ros::Time now = ros::Time::now();
-    if (last_callback_time_ > now)
+  // check if we moved backwards in time (e.g. when playing a bag file)
+  ros::Time now = ros::Time::now();
+  if (last_callback_time_ > now)
     {
-        // force re-publish of joint transforms
-        ROS_WARN("Moved backwards in time (probably because ROS clock was reset), re-publishing joint transforms!");
-        last_publish_time_.clear();
+      // force re-publish of joint transforms
+      ROS_WARN("Moved backwards in time (probably because ROS clock was reset), re-publishing joint transforms!");
+      last_publish_time_.clear();
     }
 
-    last_callback_time_ = now;
+  last_callback_time_ = now;
 
-    // determine least recently published joint
-    ros::Time last_published = now;
-    for (unsigned int i = 0; i < state->name.size(); i++)
+  // determine least recently published joint
+  ros::Time last_published = now;
+  for (unsigned int i = 0; i < state->name.size(); i++)
     {
-        ros::Time t = last_publish_time_[state->name[i]];
-        last_published = (t < last_published) ? t : last_published;
+      ros::Time t = last_publish_time_[state->name[i]];
+      last_published = (t < last_published) ? t : last_published;
     }
-    // note: if a joint was seen for the first time,
-    //       then last_published is zero.
+  // note: if a joint was seen for the first time,
+  //       then last_published is zero.
 
 
-    // check if we need to publish
-    if (state->header.stamp >= last_published + publish_interval_)
+  // check if we need to publish
+  if (state->header.stamp >= last_published + publish_interval_)
     {
-        // get joint positions from state message
-        map<string, double> joint_positions;
-        for (unsigned int i = 0; i < state->name.size(); i++)
-            joint_positions.insert(make_pair(state->name[i], state->position[i]));
+      // get joint positions from state message
+      map<string, double> joint_positions;
+      for (unsigned int i = 0; i < state->name.size(); i++)
+        joint_positions.insert(make_pair(state->name[i], state->position[i]));
 
-        for (MimicMap::iterator i = mimic_.begin(); i != mimic_.end(); i++){
-            if (joint_positions.find(i->second->joint_name) != joint_positions.end())
+      for (MimicMap::iterator i = mimic_.begin(); i != mimic_.end(); i++)
+        {
+          if (joint_positions.find(i->second->joint_name) != joint_positions.end())
             {
-                double pos = joint_positions[i->second->joint_name] * i->second->multiplier + i->second->offset;
-                joint_positions.insert(make_pair(i->first, pos));
+              double pos = joint_positions[i->second->joint_name] * i->second->multiplier + i->second->offset;
+              joint_positions.insert(make_pair(i->first, pos));
             }
         }
 
-        state_publisher_.publishTransforms(joint_positions, state->header.stamp, tf_prefix_);
+      state_publisher_.publishTransforms(joint_positions, state->header.stamp, tf_prefix_);
 
-        // store publish time in joint map
-        for (unsigned int i = 0; i < state->name.size(); i++)
+      // store publish time in joint map
+      for (unsigned int i = 0; i < state->name.size(); i++)
         {
-            last_publish_time_[state->name[i]] = state->header.stamp;
+          last_publish_time_[state->name[i]] = state->header.stamp;
         }
     }
 }
@@ -223,29 +233,29 @@ void JointStateListener::callbackJointState(const JointStateConstPtr& state)
 // ----------------------------------
 int main(int argc, char** argv)
 {
-    ros::init(argc, argv, "robot_state_publisher");
+  ros::init(argc, argv, "robot_state_publisher_123");
 
-    ///////////////////////////////////////// begin deprecation warning
-    std::string exe_name = argv[0];
-    std::size_t slash = exe_name.find_last_of("/");
-    if (slash != std::string::npos)
-        exe_name = exe_name.substr(slash + 1);
-    if (exe_name == "state_publisher")
-        ROS_WARN("The 'state_publisher' executable is deprecated. Please use 'robot_state_publisher' instead");
-    ///////////////////////////////////////// end deprecation warning
+  ///////////////////////////////////////// begin deprecation warning
+  std::string exe_name = argv[0];
+  std::size_t slash = exe_name.find_last_of("/");
+  if (slash != std::string::npos)
+    exe_name = exe_name.substr(slash + 1);
+  if (exe_name == "state_publisher")
+    ROS_WARN("The 'state_publisher' executable is deprecated. Please use 'robot_state_publisher' instead");
+  ///////////////////////////////////////// end deprecation warning
 
-    /// gets the location of the robot description on the parameter server
-    KDL::Tree tree;
-    MimicMap mimic;
-    std::string err_msg;
+  /// gets the location of the robot description on the parameter server
+  KDL::Tree tree;
+  MimicMap mimic;
+  std::string err_msg;
 
-    if (!loadTreeAndMimicMap(tree, &mimic, &err_msg))
+  if (!loadTreeAndMimicMap(tree, &mimic, &err_msg))
     {
-        ROS_ERROR("%s", err_msg.c_str());
-        return -1;
+      ROS_ERROR("%s", err_msg.c_str());
+      return -1;
     }
 
-    JointStateListener state_publisher(tree, mimic);
-    ros::spin();
-    return 0;
+  JointStateListener state_publisher(tree, mimic);
+  ros::spin();
+  return 0;
 }

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -51,92 +51,97 @@ namespace robot_state_publisher
 
 RobotStatePublisher::RobotStatePublisher(const KDL::Tree& tree)
 {
-    // walk the tree and add segments to segments_
-    updateTree(tree);
+  // walk the tree and add segments to segments_
+  updateTree(tree);
 }
 
 
 void RobotStatePublisher::updateTree(const KDL::Tree& tree)
 {
-    /// function is only called from JointStateListener::reload_robot_model
-    /// where the tree_update_mutex is acquired
+  /// function is only called from JointStateListener::reload_robot_model
+  /// where the tree_update_mutex is acquired
 
-    segments_.clear();
-    segments_fixed_.clear();
-    addChildren(tree.getRootSegment());
+  segments_.clear();
+  segments_fixed_.clear();
+  addChildren(tree.getRootSegment());
 }
 
 void RobotStatePublisher::createTreeInfo(string *msg)
 {
-    std::stringstream ss;
-    ss << "Created tree with " << segments_.size() << " moving and " << segments_fixed_.size() << " fixed segments";
-    *msg = ss.str();
+  std::stringstream ss;
+  ss << "Created tree with " << segments_.size() << " moving and " << segments_fixed_.size() << " fixed segments";
+  *msg = ss.str();
 }
 
 
 // add children to correct maps
 void RobotStatePublisher::addChildren(const KDL::SegmentMap::const_iterator segment)
 {
-    const std::string& root = GetTreeElementSegment(segment->second).getName();
+  const std::string& root = GetTreeElementSegment(segment->second).getName();
 
-    const std::vector<KDL::SegmentMap::const_iterator>& children = GetTreeElementChildren(segment->second);
-    for (unsigned int i = 0; i < children.size(); i++){
-        const KDL::Segment& child = GetTreeElementSegment(children[i]->second);
-        SegmentPair s(GetTreeElementSegment(children[i]->second), root, child.getName());
-        if (child.getJoint().getType() == KDL::Joint::None){
-            segments_fixed_.insert(make_pair(child.getJoint().getName(), s));
-            ROS_DEBUG("Adding fixed segment from %s to %s", root.c_str(), child.getName().c_str());
-        }
-        else
-        {
-            segments_.insert(make_pair(child.getJoint().getName(), s));
-            ROS_DEBUG("Adding moving segment from %s to %s", root.c_str(), child.getName().c_str());
-        }
-        addChildren(children[i]);
+  const std::vector<KDL::SegmentMap::const_iterator>& children = GetTreeElementChildren(segment->second);
+  for (unsigned int i = 0; i < children.size(); i++)
+  {
+    const KDL::Segment& child = GetTreeElementSegment(children[i]->second);
+    SegmentPair s(GetTreeElementSegment(children[i]->second), root, child.getName());
+    if (child.getJoint().getType() == KDL::Joint::None)
+    {
+      segments_fixed_.insert(make_pair(child.getJoint().getName(), s));
+      ROS_DEBUG("Adding fixed segment from %s to %s", root.c_str(), child.getName().c_str());
     }
+    else
+    {
+      segments_.insert(make_pair(child.getJoint().getName(), s));
+      ROS_DEBUG("Adding moving segment from %s to %s", root.c_str(), child.getName().c_str());
+    }
+    addChildren(children[i]);
+  }
 }
 
 
 // publish moving transforms
 void RobotStatePublisher::publishTransforms(const map<string, double>& joint_positions,
-                                            const Time& time, const std::string& tf_prefix)
+    const Time& time, const std::string& tf_prefix)
 {
-    ROS_DEBUG("Publishing transforms for moving joints");
-    std::vector<tf::StampedTransform> tf_transforms;
-    tf::StampedTransform tf_transform;
-    tf_transform.stamp_ = time;
+  ROS_DEBUG("Publishing transforms for moving joints");
+  std::vector<tf::StampedTransform> tf_transforms;
+  tf::StampedTransform tf_transform;
+  tf_transform.stamp_ = time;
 
-    // loop over all joints
-    for (map<string, double>::const_iterator jnt = joint_positions.begin(); jnt != joint_positions.end(); jnt++){
-        std::map<std::string, SegmentPair>::const_iterator seg = segments_.find(jnt->first);
-        if (seg != segments_.end()){
-            tf::transformKDLToTF(seg->second.segment.pose(jnt->second), tf_transform);
-            tf_transform.frame_id_ = tf::resolve(tf_prefix, seg->second.root);
-            tf_transform.child_frame_id_ = tf::resolve(tf_prefix, seg->second.tip);
-            tf_transforms.push_back(tf_transform);
-        }
+  // loop over all joints
+  for (map<string, double>::const_iterator jnt = joint_positions.begin(); jnt != joint_positions.end(); jnt++)
+  {
+    std::map<std::string, SegmentPair>::const_iterator seg = segments_.find(jnt->first);
+    if (seg != segments_.end())
+    {
+      tf::transformKDLToTF(seg->second.segment.pose(jnt->second), tf_transform);
+      tf_transform.frame_id_ = tf::resolve(tf_prefix, seg->second.root);
+      tf_transform.child_frame_id_ = tf::resolve(tf_prefix, seg->second.tip);
+      tf_transforms.push_back(tf_transform);
     }
-    tf_broadcaster_.sendTransform(tf_transforms);
+  }
+  tf_broadcaster_.sendTransform(tf_transforms);
 }
 
 
 /// publish fixed transforms, called via JointStateListener::pub_fixed_trafos_timer_
 void RobotStatePublisher::publishFixedTransforms(const std::string& tf_prefix)
 {
-    // cout << "publishung fixed" << endl;
-    ROS_DEBUG("Publishing transforms for fixed joints");
-    std::vector<tf::StampedTransform> tf_transforms;
-    tf::StampedTransform tf_transform;
-    tf_transform.stamp_ = ros::Time::now()+ros::Duration(0.5);  // future publish by 0.5 seconds
+  // cout << "publishung fixed" << endl;
+  ROS_DEBUG("Publishing transforms for fixed joints");
+  std::vector<tf::StampedTransform> tf_transforms;
+  tf::StampedTransform tf_transform;
+  tf_transform.stamp_ = ros::Time::now() + ros::Duration(0.5);  // future publish by 0.5 seconds
 
-    // loop over all fixed segments
-    for (map<string, SegmentPair>::const_iterator seg = segments_fixed_.begin(); seg != segments_fixed_.end(); seg++){
-        tf::transformKDLToTF(seg->second.segment.pose(0), tf_transform);
-        tf_transform.frame_id_ = tf::resolve(tf_prefix, seg->second.root);
-        tf_transform.child_frame_id_ = tf::resolve(tf_prefix, seg->second.tip);
-        tf_transforms.push_back(tf_transform);
-    }
-    tf_broadcaster_.sendTransform(tf_transforms);
+  // loop over all fixed segments
+  for (map<string, SegmentPair>::const_iterator seg = segments_fixed_.begin(); seg != segments_fixed_.end(); seg++)
+  {
+    tf::transformKDLToTF(seg->second.segment.pose(0), tf_transform);
+    tf_transform.frame_id_ = tf::resolve(tf_prefix, seg->second.root);
+    tf_transform.child_frame_id_ = tf::resolve(tf_prefix, seg->second.tip);
+    tf_transforms.push_back(tf_transform);
+  }
+  tf_broadcaster_.sendTransform(tf_transforms);
 }
 
 

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -37,12 +37,17 @@
 #include "robot_state_publisher/robot_state_publisher.h"
 #include <kdl/frames_io.hpp>
 #include <tf_conversions/tf_kdl.h>
+#include <map>
+#include <string>
+#include <vector>
 
 
-using namespace std;
-using namespace ros;
+using std::string;
+using std::map;
+using ros::Time;
 
-namespace robot_state_publisher{
+namespace robot_state_publisher
+{
 
 RobotStatePublisher::RobotStatePublisher(const KDL::Tree& tree)
 {
@@ -51,21 +56,21 @@ RobotStatePublisher::RobotStatePublisher(const KDL::Tree& tree)
 }
 
 
-void RobotStatePublisher::updateTree(const KDL::Tree& tree){
-
+void RobotStatePublisher::updateTree(const KDL::Tree& tree)
+{
     /// function is only called from JointStateListener::reload_robot_model
     /// where the tree_update_mutex is acquired
 
     segments_.clear();
     segments_fixed_.clear();
     addChildren(tree.getRootSegment());
-
 }
 
-void RobotStatePublisher::createTreeInfo(string &msg){
+void RobotStatePublisher::createTreeInfo(string *msg)
+{
     std::stringstream ss;
     ss << "Created tree with " << segments_.size() << " moving and " << segments_fixed_.size() << " fixed segments";
-    msg = ss.str();
+    *msg = ss.str();
 }
 
 
@@ -75,14 +80,15 @@ void RobotStatePublisher::addChildren(const KDL::SegmentMap::const_iterator segm
     const std::string& root = GetTreeElementSegment(segment->second).getName();
 
     const std::vector<KDL::SegmentMap::const_iterator>& children = GetTreeElementChildren(segment->second);
-    for (unsigned int i=0; i<children.size(); i++){
+    for (unsigned int i = 0; i < children.size(); i++){
         const KDL::Segment& child = GetTreeElementSegment(children[i]->second);
         SegmentPair s(GetTreeElementSegment(children[i]->second), root, child.getName());
         if (child.getJoint().getType() == KDL::Joint::None){
             segments_fixed_.insert(make_pair(child.getJoint().getName(), s));
             ROS_DEBUG("Adding fixed segment from %s to %s", root.c_str(), child.getName().c_str());
         }
-        else{
+        else
+        {
             segments_.insert(make_pair(child.getJoint().getName(), s));
             ROS_DEBUG("Adding moving segment from %s to %s", root.c_str(), child.getName().c_str());
         }
@@ -92,16 +98,16 @@ void RobotStatePublisher::addChildren(const KDL::SegmentMap::const_iterator segm
 
 
 // publish moving transforms
-void RobotStatePublisher::publishTransforms(const map<string, double>& joint_positions, const Time& time, const std::string& tf_prefix)
+void RobotStatePublisher::publishTransforms(const map<string, double>& joint_positions,
+                                            const Time& time, const std::string& tf_prefix)
 {
-
     ROS_DEBUG("Publishing transforms for moving joints");
     std::vector<tf::StampedTransform> tf_transforms;
     tf::StampedTransform tf_transform;
     tf_transform.stamp_ = time;
 
     // loop over all joints
-    for (map<string, double>::const_iterator jnt=joint_positions.begin(); jnt != joint_positions.end(); jnt++){
+    for (map<string, double>::const_iterator jnt = joint_positions.begin(); jnt != joint_positions.end(); jnt++){
         std::map<std::string, SegmentPair>::const_iterator seg = segments_.find(jnt->first);
         if (seg != segments_.end()){
             tf::transformKDLToTF(seg->second.segment.pose(jnt->second), tf_transform);
@@ -117,7 +123,6 @@ void RobotStatePublisher::publishTransforms(const map<string, double>& joint_pos
 /// publish fixed transforms, called via JointStateListener::pub_fixed_trafos_timer_
 void RobotStatePublisher::publishFixedTransforms(const std::string& tf_prefix)
 {
-
     // cout << "publishung fixed" << endl;
     ROS_DEBUG("Publishing transforms for fixed joints");
     std::vector<tf::StampedTransform> tf_transforms;
@@ -125,18 +130,17 @@ void RobotStatePublisher::publishFixedTransforms(const std::string& tf_prefix)
     tf_transform.stamp_ = ros::Time::now()+ros::Duration(0.5);  // future publish by 0.5 seconds
 
     // loop over all fixed segments
-    for (map<string, SegmentPair>::const_iterator seg=segments_fixed_.begin(); seg != segments_fixed_.end(); seg++){
+    for (map<string, SegmentPair>::const_iterator seg = segments_fixed_.begin(); seg != segments_fixed_.end(); seg++){
         tf::transformKDLToTF(seg->second.segment.pose(0), tf_transform);
         tf_transform.frame_id_ = tf::resolve(tf_prefix, seg->second.root);
         tf_transform.child_frame_id_ = tf::resolve(tf_prefix, seg->second.tip);
         tf_transforms.push_back(tf_transform);
     }
     tf_broadcaster_.sendTransform(tf_transforms);
-
 }
 
 
-}
+}  // namespace robot_state_publisher
 
 
 

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -1,13 +1,13 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
- * 
+ *
  *  Copyright (c) 2008, Willow Garage, Inc.
  *  All rights reserved.
- * 
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions
  *  are met:
- * 
+ *
  *   * Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
  *   * Redistributions in binary form must reproduce the above
@@ -17,7 +17,7 @@
  *   * Neither the name of the Willow Garage nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
- * 
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -38,45 +38,63 @@
 #include <kdl/frames_io.hpp>
 #include <tf_conversions/tf_kdl.h>
 
+
 using namespace std;
 using namespace ros;
 
-
-
 namespace robot_state_publisher{
 
-  RobotStatePublisher::RobotStatePublisher(const KDL::Tree& tree)
-  {
+RobotStatePublisher::RobotStatePublisher(const KDL::Tree& tree)
+{
     // walk the tree and add segments to segments_
+    updateTree(tree);
+}
+
+
+void RobotStatePublisher::updateTree(const KDL::Tree& tree){
+
+    /// function is only called from JointStateListener::reload_robot_model
+    /// where the tree_update_mutex is acquired
+
+    segments_.clear();
+    segments_fixed_.clear();
     addChildren(tree.getRootSegment());
-  }
+
+}
+
+void RobotStatePublisher::createTreeInfo(string &msg){
+    std::stringstream ss;
+    ss << "Created tree with " << segments_.size() << " moving and " << segments_fixed_.size() << " fixed segments";
+    msg = ss.str();
+}
 
 
-  // add children to correct maps
-  void RobotStatePublisher::addChildren(const KDL::SegmentMap::const_iterator segment)
-  {
+// add children to correct maps
+void RobotStatePublisher::addChildren(const KDL::SegmentMap::const_iterator segment)
+{
     const std::string& root = GetTreeElementSegment(segment->second).getName();
 
     const std::vector<KDL::SegmentMap::const_iterator>& children = GetTreeElementChildren(segment->second);
     for (unsigned int i=0; i<children.size(); i++){
-      const KDL::Segment& child = GetTreeElementSegment(children[i]->second);
-      SegmentPair s(GetTreeElementSegment(children[i]->second), root, child.getName());
-      if (child.getJoint().getType() == KDL::Joint::None){
-        segments_fixed_.insert(make_pair(child.getJoint().getName(), s));
-        ROS_DEBUG("Adding fixed segment from %s to %s", root.c_str(), child.getName().c_str());
-      }
-      else{
-        segments_.insert(make_pair(child.getJoint().getName(), s));
-        ROS_DEBUG("Adding moving segment from %s to %s", root.c_str(), child.getName().c_str());
-      }
-      addChildren(children[i]);
+        const KDL::Segment& child = GetTreeElementSegment(children[i]->second);
+        SegmentPair s(GetTreeElementSegment(children[i]->second), root, child.getName());
+        if (child.getJoint().getType() == KDL::Joint::None){
+            segments_fixed_.insert(make_pair(child.getJoint().getName(), s));
+            ROS_DEBUG("Adding fixed segment from %s to %s", root.c_str(), child.getName().c_str());
+        }
+        else{
+            segments_.insert(make_pair(child.getJoint().getName(), s));
+            ROS_DEBUG("Adding moving segment from %s to %s", root.c_str(), child.getName().c_str());
+        }
+        addChildren(children[i]);
     }
-  }
+}
 
 
-  // publish moving transforms
-  void RobotStatePublisher::publishTransforms(const map<string, double>& joint_positions, const Time& time, const std::string& tf_prefix)
-  {
+// publish moving transforms
+void RobotStatePublisher::publishTransforms(const map<string, double>& joint_positions, const Time& time, const std::string& tf_prefix)
+{
+
     ROS_DEBUG("Publishing transforms for moving joints");
     std::vector<tf::StampedTransform> tf_transforms;
     tf::StampedTransform tf_transform;
@@ -84,21 +102,23 @@ namespace robot_state_publisher{
 
     // loop over all joints
     for (map<string, double>::const_iterator jnt=joint_positions.begin(); jnt != joint_positions.end(); jnt++){
-      std::map<std::string, SegmentPair>::const_iterator seg = segments_.find(jnt->first);
-      if (seg != segments_.end()){
-        tf::transformKDLToTF(seg->second.segment.pose(jnt->second), tf_transform);    
-        tf_transform.frame_id_ = tf::resolve(tf_prefix, seg->second.root);
-        tf_transform.child_frame_id_ = tf::resolve(tf_prefix, seg->second.tip);
-        tf_transforms.push_back(tf_transform);
-      }
+        std::map<std::string, SegmentPair>::const_iterator seg = segments_.find(jnt->first);
+        if (seg != segments_.end()){
+            tf::transformKDLToTF(seg->second.segment.pose(jnt->second), tf_transform);
+            tf_transform.frame_id_ = tf::resolve(tf_prefix, seg->second.root);
+            tf_transform.child_frame_id_ = tf::resolve(tf_prefix, seg->second.tip);
+            tf_transforms.push_back(tf_transform);
+        }
     }
     tf_broadcaster_.sendTransform(tf_transforms);
-  }
+}
 
 
-  // publish fixed transforms
-  void RobotStatePublisher::publishFixedTransforms(const std::string& tf_prefix)
-  {
+/// publish fixed transforms, called via JointStateListener::pub_fixed_trafos_timer_
+void RobotStatePublisher::publishFixedTransforms(const std::string& tf_prefix)
+{
+
+    // cout << "publishung fixed" << endl;
     ROS_DEBUG("Publishing transforms for fixed joints");
     std::vector<tf::StampedTransform> tf_transforms;
     tf::StampedTransform tf_transform;
@@ -106,13 +126,15 @@ namespace robot_state_publisher{
 
     // loop over all fixed segments
     for (map<string, SegmentPair>::const_iterator seg=segments_fixed_.begin(); seg != segments_fixed_.end(); seg++){
-      tf::transformKDLToTF(seg->second.segment.pose(0), tf_transform);    
-      tf_transform.frame_id_ = tf::resolve(tf_prefix, seg->second.root);
-      tf_transform.child_frame_id_ = tf::resolve(tf_prefix, seg->second.tip);
-      tf_transforms.push_back(tf_transform);
+        tf::transformKDLToTF(seg->second.segment.pose(0), tf_transform);
+        tf_transform.frame_id_ = tf::resolve(tf_prefix, seg->second.root);
+        tf_transform.child_frame_id_ = tf::resolve(tf_prefix, seg->second.tip);
+        tf_transforms.push_back(tf_transform);
     }
     tf_broadcaster_.sendTransform(tf_transforms);
-  }
+
+}
+
 
 }
 

--- a/src/treefksolverposfull_recursive.cpp
+++ b/src/treefksolverposfull_recursive.cpp
@@ -25,25 +25,32 @@
 #include <iostream>
 #include <cstdio>
 #include <map>
-using namespace std;
+#include <vector>
+#include <string>
+
+using std::map;
+using std::string;
+using std::vector;
+
+
 
 
 namespace KDL
 {
 
-TreeFkSolverPosFull_recursive::TreeFkSolverPosFull_recursive(const Tree& _tree):
+  TreeFkSolverPosFull_recursive::TreeFkSolverPosFull_recursive(const Tree& _tree):
     tree(_tree)
-{
-}
+  {
+  }
 
-TreeFkSolverPosFull_recursive::~TreeFkSolverPosFull_recursive()
-{
-}
+  TreeFkSolverPosFull_recursive::~TreeFkSolverPosFull_recursive()
+  {
+  }
 
 
-int TreeFkSolverPosFull_recursive::JntToCart(const map<string, double>& q_in, map<string,
-                                             tf::Stamped<Frame> >& p_out, bool flatten_tree)
-{      
+  int TreeFkSolverPosFull_recursive::JntToCart(const map<string, double>& q_in, map < string,
+                                               tf::Stamped<Frame> > & p_out, bool flatten_tree)
+  {
     // clear output
     p_out.clear();
 
@@ -53,41 +60,46 @@ int TreeFkSolverPosFull_recursive::JntToCart(const map<string, double>& q_in, ma
                   tree.getRootSegment(), flatten_tree);
 
     return 0;
-}
+  }
 
 
 
-void TreeFkSolverPosFull_recursive::addFrameToMap(const map<string, double>& q_in, 
-                                                  map<string, tf::Stamped<Frame> >& p_out,
-                                                  const tf::Stamped<KDL::Frame>& previous_frame,
-                                                  const SegmentMap::const_iterator this_segment,
-                                                  bool flatten_tree)
-{
+  void TreeFkSolverPosFull_recursive::addFrameToMap(const map<string, double>& q_in,
+                                                    map<string, tf::Stamped<Frame> >& p_out,
+                                                    const tf::Stamped<KDL::Frame>& previous_frame,
+                                                    const SegmentMap::const_iterator this_segment,
+                                                    bool flatten_tree)
+  {
     // get pose of this segment
     tf::Stamped<KDL::Frame> this_frame;
     double jnt_p = 0;
-    if (GetTreeElementSegment(this_segment->second).getJoint().getType() != Joint::None){
+    if (GetTreeElementSegment(this_segment->second).getJoint().getType() != Joint::None)
+      {
         map<string, double>::const_iterator jnt_pos = q_in.find(GetTreeElementSegment(this_segment->second).getJoint().getName());
-        if (jnt_pos == q_in.end()){
-            ROS_DEBUG("Warning: TreeFKSolverPosFull Could not find value for joint '%s'. Skipping this tree branch", this_segment->first.c_str());
+        if (jnt_pos == q_in.end())
+          {
+            ROS_DEBUG("Warning: TreeFKSolverPosFull Could not find value for joint '%s'. Skipping this tree branch",
+                      this_segment->first.c_str());
             return;
-        }
+          }
         jnt_p = jnt_pos->second;
-    }
-    this_frame = tf::Stamped<KDL::Frame>(previous_frame * GetTreeElementSegment(this_segment->second).pose(jnt_p), ros::Time(), previous_frame.frame_id_);
+      }
+    this_frame = tf::Stamped<KDL::Frame>(previous_frame * GetTreeElementSegment(this_segment->second).pose(jnt_p),
+                                         ros::Time(), previous_frame.frame_id_);
 
     if (this_segment->first != tree.getRootSegment()->first)
-        p_out.insert(make_pair(this_segment->first, tf::Stamped<KDL::Frame>(this_frame, ros::Time(), previous_frame.frame_id_)));
+      p_out.insert(make_pair(this_segment->first, tf::Stamped<KDL::Frame>(this_frame, ros::Time(), previous_frame.frame_id_)));
 
     // get poses of child segments
     for (vector<SegmentMap::const_iterator>::const_iterator child = GetTreeElementChildren(this_segment->second).begin();
          child != GetTreeElementChildren(this_segment->second).end(); child++)
-    {
+      {
         if (flatten_tree)
-            addFrameToMap(q_in, p_out, this_frame, *child, flatten_tree);
+          addFrameToMap(q_in, p_out, this_frame, *child, flatten_tree);
         else
-            addFrameToMap(q_in, p_out, tf::Stamped<KDL::Frame>(KDL::Frame::Identity(), ros::Time(), this_segment->first), *child, flatten_tree);
-    }
-}
+          addFrameToMap(q_in, p_out, tf::Stamped<KDL::Frame>(KDL::Frame::Identity(), ros::Time(),
+                                                             this_segment->first), *child, flatten_tree);
+      }
+  }
 
 }  // namespace KDL

--- a/src/treefksolverposfull_recursive.cpp
+++ b/src/treefksolverposfull_recursive.cpp
@@ -24,13 +24,15 @@
 #include <ros/ros.h>
 #include <iostream>
 #include <cstdio>
-
+#include <map>
 using namespace std;
 
-namespace KDL {
+
+namespace KDL
+{
 
 TreeFkSolverPosFull_recursive::TreeFkSolverPosFull_recursive(const Tree& _tree):
-  tree(_tree)
+    tree(_tree)
 {
 }
 
@@ -39,49 +41,53 @@ TreeFkSolverPosFull_recursive::~TreeFkSolverPosFull_recursive()
 }
 
 
-int TreeFkSolverPosFull_recursive::JntToCart(const map<string, double>& q_in, map<string, tf::Stamped<Frame> >& p_out, bool flatten_tree)
+int TreeFkSolverPosFull_recursive::JntToCart(const map<string, double>& q_in, map<string,
+                                             tf::Stamped<Frame> >& p_out, bool flatten_tree)
 {      
-  // clear output
-  p_out.clear();
+    // clear output
+    p_out.clear();
 
-  addFrameToMap(q_in, p_out, tf::Stamped<KDL::Frame>(KDL::Frame::Identity(), ros::Time(), GetTreeElementSegment(tree.getRootSegment()->second).getName()),
-                tree.getRootSegment(), flatten_tree);
+    addFrameToMap(q_in, p_out, tf::Stamped<KDL::Frame>(KDL::Frame::Identity(),
+                                                       ros::Time(),
+                                                       GetTreeElementSegment(tree.getRootSegment()->second).getName()),
+                  tree.getRootSegment(), flatten_tree);
 
-  return 0;
+    return 0;
 }
 
 
-					     
+
 void TreeFkSolverPosFull_recursive::addFrameToMap(const map<string, double>& q_in, 
-						  map<string, tf::Stamped<Frame> >& p_out,
-						  const tf::Stamped<KDL::Frame>& previous_frame,
-						  const SegmentMap::const_iterator this_segment,
-						  bool flatten_tree)
+                                                  map<string, tf::Stamped<Frame> >& p_out,
+                                                  const tf::Stamped<KDL::Frame>& previous_frame,
+                                                  const SegmentMap::const_iterator this_segment,
+                                                  bool flatten_tree)
 {
-  // get pose of this segment
-  tf::Stamped<KDL::Frame> this_frame;
-  double jnt_p = 0;
-  if (GetTreeElementSegment(this_segment->second).getJoint().getType() != Joint::None){
-    map<string, double>::const_iterator jnt_pos = q_in.find(GetTreeElementSegment(this_segment->second).getJoint().getName());
-    if (jnt_pos == q_in.end()){
-      ROS_DEBUG("Warning: TreeFKSolverPosFull Could not find value for joint '%s'. Skipping this tree branch", this_segment->first.c_str());
-      return;
+    // get pose of this segment
+    tf::Stamped<KDL::Frame> this_frame;
+    double jnt_p = 0;
+    if (GetTreeElementSegment(this_segment->second).getJoint().getType() != Joint::None){
+        map<string, double>::const_iterator jnt_pos = q_in.find(GetTreeElementSegment(this_segment->second).getJoint().getName());
+        if (jnt_pos == q_in.end()){
+            ROS_DEBUG("Warning: TreeFKSolverPosFull Could not find value for joint '%s'. Skipping this tree branch", this_segment->first.c_str());
+            return;
+        }
+        jnt_p = jnt_pos->second;
     }
-    jnt_p = jnt_pos->second;
-  }
-  this_frame = tf::Stamped<KDL::Frame>(previous_frame * GetTreeElementSegment(this_segment->second).pose(jnt_p), ros::Time(), previous_frame.frame_id_);
+    this_frame = tf::Stamped<KDL::Frame>(previous_frame * GetTreeElementSegment(this_segment->second).pose(jnt_p), ros::Time(), previous_frame.frame_id_);
 
-  if (this_segment->first != tree.getRootSegment()->first)
-    p_out.insert(make_pair(this_segment->first, tf::Stamped<KDL::Frame>(this_frame, ros::Time(), previous_frame.frame_id_)));
+    if (this_segment->first != tree.getRootSegment()->first)
+        p_out.insert(make_pair(this_segment->first, tf::Stamped<KDL::Frame>(this_frame, ros::Time(), previous_frame.frame_id_)));
 
-  // get poses of child segments
-  for (vector<SegmentMap::const_iterator>::const_iterator child = GetTreeElementChildren(this_segment->second).begin();
-        child != GetTreeElementChildren(this_segment->second).end(); child++){
-    if (flatten_tree)
-      addFrameToMap(q_in, p_out, this_frame, *child, flatten_tree);
-    else
-      addFrameToMap(q_in, p_out, tf::Stamped<KDL::Frame>(KDL::Frame::Identity(), ros::Time(), this_segment->first), *child, flatten_tree);
-  }      
+    // get poses of child segments
+    for (vector<SegmentMap::const_iterator>::const_iterator child = GetTreeElementChildren(this_segment->second).begin();
+         child != GetTreeElementChildren(this_segment->second).end(); child++)
+    {
+        if (flatten_tree)
+            addFrameToMap(q_in, p_out, this_frame, *child, flatten_tree);
+        else
+            addFrameToMap(q_in, p_out, tf::Stamped<KDL::Frame>(KDL::Frame::Identity(), ros::Time(), this_segment->first), *child, flatten_tree);
+    }
 }
 
-}
+}  // namespace KDL

--- a/test/test_one_link.cpp
+++ b/test/test_one_link.cpp
@@ -44,11 +44,6 @@
 #include "robot_state_publisher/joint_state_listener.h"
 
 
-using namespace ros;
-using namespace tf;
-using namespace robot_state_publisher;
-
-
 int g_argc;
 char** g_argv;
 
@@ -82,7 +77,8 @@ TEST_F(TestPublisher, test)
   ros::NodeHandle n;
   ros::Publisher js_pub = n.advertise<sensor_msgs::JointState>("joint_states", 100);
   sensor_msgs::JointState js_msg;
-  for (unsigned int i=0; i<100; i++){
+  for (unsigned int i = 0; i < 100; i++)
+  {
     js_msg.header.stamp = ros::Time::now();
     js_pub.publish(js_msg);
     ros::Duration(0.1).sleep();

--- a/test/test_publisher.cpp
+++ b/test/test_publisher.cpp
@@ -44,9 +44,9 @@
 #include "robot_state_publisher/joint_state_listener.h"
 
 
-using namespace ros;
-using namespace tf;
-using namespace robot_state_publisher;
+// using namespace ros;
+// using namespace tf;
+// using namespace robot_state_publisher;
 
 
 int g_argc;
@@ -89,12 +89,12 @@ TEST_F(TestPublisher, test)
   ASSERT_FALSE(tf.canTransform("base_link", "wim_link", Time()));
 
   tf::StampedTransform t;
-  tf.lookupTransform("base_link", "r_gripper_palm_link",Time(), t );
+  tf.lookupTransform("base_link", "r_gripper_palm_link", Time(), t);
   EXPECT_NEAR(t.getOrigin().x(), 0.769198, EPS);
   EXPECT_NEAR(t.getOrigin().y(), -0.188800, EPS);
   EXPECT_NEAR(t.getOrigin().z(), 0.764914, EPS);
-  
-  tf.lookupTransform("l_gripper_palm_link", "r_gripper_palm_link",Time(), t );
+
+  tf.lookupTransform("l_gripper_palm_link", "r_gripper_palm_link", Time(), t);
   EXPECT_NEAR(t.getOrigin().x(), 0.000384222, EPS);
   EXPECT_NEAR(t.getOrigin().y(), -0.376021, EPS);
   EXPECT_NEAR(t.getOrigin().z(), -1.0858e-05, EPS);

--- a/test/test_two_links_fixed_joint.cpp
+++ b/test/test_two_links_fixed_joint.cpp
@@ -44,9 +44,9 @@
 #include "robot_state_publisher/joint_state_listener.h"
 
 
-using namespace ros;
-using namespace tf;
-using namespace robot_state_publisher;
+// using namespace ros;
+// using namespace tf;
+// using namespace robot_state_publisher;
 
 
 int g_argc;
@@ -86,7 +86,7 @@ TEST_F(TestPublisher, test)
   ASSERT_FALSE(tf.canTransform("base_link", "wim_link", Time()));
 
   tf::StampedTransform t;
-  tf.lookupTransform("link1", "link2",Time(), t );
+  tf.lookupTransform("link1", "link2", Time(), t);
   EXPECT_NEAR(t.getOrigin().x(), 5.0, EPS);
   EXPECT_NEAR(t.getOrigin().y(), 0.0, EPS);
   EXPECT_NEAR(t.getOrigin().z(), 0.0, EPS);

--- a/test/test_two_links_fixed_joint.cpp
+++ b/test/test_two_links_fixed_joint.cpp
@@ -44,9 +44,9 @@
 #include "robot_state_publisher/joint_state_listener.h"
 
 
-// using namespace ros;
-// using namespace tf;
-// using namespace robot_state_publisher;
+using namespace ros;
+using namespace tf;
+using namespace robot_state_publisher;
 
 
 int g_argc;

--- a/test/test_two_links_moving_joint.cpp
+++ b/test/test_two_links_moving_joint.cpp
@@ -44,9 +44,9 @@
 #include "robot_state_publisher/joint_state_listener.h"
 
 
-using namespace ros;
-using namespace tf;
-using namespace robot_state_publisher;
+// using namespace ros;
+// using namespace tf;
+// using namespace robot_state_publisher;
 
 
 int g_argc;
@@ -84,7 +84,8 @@ TEST_F(TestPublisher, test)
   sensor_msgs::JointState js_msg;
   js_msg.name.push_back("joint1");
   js_msg.position.push_back(M_PI);
-  for (unsigned int i=0; i<100; i++){
+  for (unsigned int i = 0; i < 100; i++)
+  {
     js_msg.header.stamp = ros::Time::now();
     js_pub.publish(js_msg);
     ros::Duration(0.1).sleep();
@@ -94,7 +95,7 @@ TEST_F(TestPublisher, test)
   ASSERT_FALSE(tf.canTransform("base_link", "wim_link", Time()));
 
   tf::StampedTransform t;
-  tf.lookupTransform("link1", "link2",Time(), t );
+  tf.lookupTransform("link1", "link2", Time(), t);
   EXPECT_NEAR(t.getOrigin().x(), 5.0, EPS);
   EXPECT_NEAR(t.getOrigin().y(), 0.0, EPS);
   EXPECT_NEAR(t.getOrigin().z(), 0.0, EPS);


### PR DESCRIPTION
Node now advertises  a reload_robot_model (std_srvs/Trigger) service that allows another node to trigger a reload of the robot model (e.g. after an calibration that changed the urdf-model).

So far, the robot_state_publisher had to be restarted, which is not suitable for an automated process.  With the new adaption, the server can be restarted by calling the service:

```
c = rospy.ServiceProxy("/robot_state_publisher/reload_robot_model", Trigger)
result = c()
print result.success, result.message
```

If the reload failed (e.g. due to a wrong urdf-model (rosparam set /robot_description "InvalidFooBar"), the publisher stops and no tf-frames are published anymore so that no one is working with the deprecated model. If the /robot_description is corrected and the service called again, the publisher continues to publish frames. 

Publication of frames is stopped before loading the model, so that reading and writing does not happen at the same time. 

Discussion in Issue 29:
https://github.com/ros/robot_state_publisher/issues/29
