### PR TITLE
Check URDF to distinguish fixed joints from floating joints. Floating…

### DIFF
--- a/include/robot_state_publisher/joint_state_listener.h
+++ b/include/robot_state_publisher/joint_state_listener.h
@@ -57,7 +57,7 @@ public:
   /** Constructor
    * \param tree The kinematic model of a robot, represented by a KDL Tree
    */
-  JointStateListener(const KDL::Tree& tree, const MimicMap& m);
+  JointStateListener(const KDL::Tree& tree, const MimicMap& m, const urdf::Model& model = urdf::Model());
 
   /// Destructor
   ~JointStateListener();

--- a/include/robot_state_publisher/robot_state_publisher.h
+++ b/include/robot_state_publisher/robot_state_publisher.h
@@ -41,6 +41,7 @@
 #include <boost/scoped_ptr.hpp>
 #include <tf/tf.h>
 #include <tf/transform_broadcaster.h>
+#include <urdf/model.h>
 #include <kdl/frames.hpp>
 #include <kdl/segment.hpp>
 #include <kdl/tree.hpp>
@@ -64,7 +65,7 @@ public:
   /** Constructor
    * \param tree The kinematic model of a robot, represented by a KDL Tree 
    */
-  RobotStatePublisher(const KDL::Tree& tree);
+  RobotStatePublisher(const KDL::Tree& tree, const urdf::Model& model = urdf::Model());
 
   /// Destructor
   ~RobotStatePublisher(){};
@@ -82,6 +83,7 @@ private:
 
   std::map<std::string, SegmentPair> segments_, segments_fixed_;
   tf::TransformBroadcaster tf_broadcaster_;
+  const urdf::Model& model_;
 };
 
 

--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -47,8 +47,8 @@ using namespace ros;
 using namespace KDL;
 using namespace robot_state_publisher;
 
-JointStateListener::JointStateListener(const KDL::Tree& tree, const MimicMap& m)
-  : state_publisher_(tree), mimic_(m)
+JointStateListener::JointStateListener(const KDL::Tree& tree, const MimicMap& m, const urdf::Model& model)
+  : state_publisher_(tree, model), mimic_(m)
 {
   ros::NodeHandle n_tilde("~");
   ros::NodeHandle n;
@@ -164,7 +164,7 @@ int main(int argc, char** argv)
     }
   }
 
-  JointStateListener state_publisher(tree, mimic);
+  JointStateListener state_publisher(tree, mimic, model);
   ros::spin();
 
   return 0;


### PR DESCRIPTION
… joints are ignored by the publisher (no segment is added for them).

Fixes #19 

Maybe [this](https://github.com/ros/robot_model/blob/indigo-devel/kdl_parser/src/kdl_parser.cpp#L88) warning should be modified to make it clear that it happens at the KDL level only, but the robot_state_publisher is still able to distinguish.
