### PR TITLE
Fix API break in publishFixedTransforms

### DIFF
--- a/include/robot_state_publisher/robot_state_publisher.h
+++ b/include/robot_state_publisher/robot_state_publisher.h
@@ -76,7 +76,7 @@ public:
    * \param time The time at which the joint positions were recorded
    */
   void publishTransforms(const std::map<std::string, double>& joint_positions, const ros::Time& time, const std::string& tf_prefix);
-  void publishFixedTransforms(const std::string& tf_prefix, bool use_tf_static);
+  void publishFixedTransforms(const std::string& tf_prefix, bool use_tf_static = false);
 
 private:
   void addChildren(const KDL::SegmentMap::const_iterator segment);


### PR DESCRIPTION
A bool argument was added to
RobotStatePublisher::publishFixedTransforms
which broke API.
I've added a default value of false, to match
the default specified in the JointStateListener
constructor.

Fixes #38.
