### PR TITLE
Implement public default constructor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,11 @@ target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME}_solver ${orocos_kdl_LIBRAR
 add_executable(state_publisher src/joint_state_listener.cpp)
 target_link_libraries(state_publisher ${PROJECT_NAME}_solver ${orocos_kdl_LIBRARIES})
 
+add_library(joint_state_listener
+  src/joint_state_listener.cpp
+)
+target_link_libraries(joint_state_listener ${PROJECT_NAME}_solver)
+
 # Tests
 
 if (CATKIN_ENABLE_TESTING)
@@ -41,6 +46,9 @@ if (CATKIN_ENABLE_TESTING)
 
   add_rostest_gtest(test_two_links_fixed_joint ${CMAKE_CURRENT_SOURCE_DIR}/test/test_two_links_fixed_joint.launch test/test_two_links_fixed_joint.cpp)
   target_link_libraries(test_two_links_fixed_joint ${catkin_LIBRARIES} ${PROJECT_NAME}_solver)
+
+  add_rostest_gtest(test_init ${CMAKE_CURRENT_SOURCE_DIR}/test/test_init.launch test/test_init.cpp)
+  target_link_libraries(test_init ${catkin_LIBRARIES} joint_state_listener)
 
   add_rostest_gtest(test_two_links_moving_joint ${CMAKE_CURRENT_SOURCE_DIR}/test/test_two_links_moving_joint.launch test/test_two_links_moving_joint.cpp)
   target_link_libraries(test_two_links_moving_joint ${catkin_LIBRARIES} ${PROJECT_NAME}_solver)
@@ -56,14 +64,11 @@ if (CATKIN_ENABLE_TESTING)
   add_rostest_gtest(test_joint_states_bag ${CMAKE_CURRENT_SOURCE_DIR}/test/test_joint_states_bag.launch test/test_joint_states_bag.cpp)
   target_link_libraries(test_joint_states_bag ${catkin_LIBRARIES} ${PROJECT_NAME}_solver)
 
-  add_rostest_gtest(test_init ${CMAKE_CURRENT_SOURCE_DIR}/test/test_init.launch test/test_init.cpp)
-  target_link_libraries(test_init ${catkin_LIBRARIES} ${PROJECT_NAME}_solver)
-
   install(FILES test/one_link.urdf test/pr2.urdf test/two_links_fixed_joint.urdf test/two_links_moving_joint.urdf DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/test)
 
 endif()
 
-install(TARGETS ${PROJECT_NAME}_solver ${PROJECT_NAME} state_publisher
+install(TARGETS ${PROJECT_NAME}_solver ${PROJECT_NAME} state_publisher joint_state_listener
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,9 @@ target_link_libraries(state_publisher ${PROJECT_NAME}_solver ${orocos_kdl_LIBRAR
 # Tests
 
 if (CATKIN_ENABLE_TESTING)
+  if(NOT WIN32)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+  endif()
 
   add_rostest_gtest(test_one_link ${CMAKE_CURRENT_SOURCE_DIR}/test/test_one_link.launch test/test_one_link.cpp)
   target_link_libraries(test_one_link ${catkin_LIBRARIES} ${PROJECT_NAME}_solver)
@@ -52,6 +55,9 @@ if (CATKIN_ENABLE_TESTING)
 
   add_rostest_gtest(test_joint_states_bag ${CMAKE_CURRENT_SOURCE_DIR}/test/test_joint_states_bag.launch test/test_joint_states_bag.cpp)
   target_link_libraries(test_joint_states_bag ${catkin_LIBRARIES} ${PROJECT_NAME}_solver)
+
+  add_rostest_gtest(test_init ${CMAKE_CURRENT_SOURCE_DIR}/test/test_init.launch test/test_init.cpp)
+  target_link_libraries(test_init ${catkin_LIBRARIES} ${PROJECT_NAME}_solver)
 
   install(FILES test/one_link.urdf test/pr2.urdf test/two_links_fixed_joint.urdf test/two_links_moving_joint.urdf DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/test)
 

--- a/include/robot_state_publisher/joint_state_listener.h
+++ b/include/robot_state_publisher/joint_state_listener.h
@@ -54,10 +54,19 @@ namespace robot_state_publisher{
 
 class JointStateListener{
 public:
+  static void constructMimicMap(MimicMap & mimic_map, urdf::Model & model);
+
   /** Constructor
    * \param tree The kinematic model of a robot, represented by a KDL Tree
    */
   JointStateListener(const KDL::Tree& tree, const MimicMap& m, const urdf::Model& model = urdf::Model());
+
+  /**
+   * Default constructor
+   */
+  JointStateListener();
+
+  void init(const KDL::Tree& tree, const MimicMap& m, const urdf::Model& model = urdf::Model());
 
   /// Destructor
   ~JointStateListener();

--- a/include/robot_state_publisher/robot_state_publisher.h
+++ b/include/robot_state_publisher/robot_state_publisher.h
@@ -68,8 +68,18 @@ public:
    */
   RobotStatePublisher(const KDL::Tree& tree, const urdf::Model& model = urdf::Model());
 
+  /** Default constructor
+   */
+  RobotStatePublisher();
+
   /// Destructor
   ~RobotStatePublisher(){};
+
+  /* Initialization method
+   * For delayed initialization of the robot model (e.g. if default constructor is used)
+   * \param tree The kinematic model of a robot, represented by a KDL Tree
+   */
+  void init(const KDL::Tree& tree, const urdf::Model& model = urdf::Model());
 
   /** Publish transforms to tf
    * \param joint_positions A map of joint names and joint positions.
@@ -82,7 +92,7 @@ private:
   void addChildren(const KDL::SegmentMap::const_iterator segment);
 
   std::map<std::string, SegmentPair> segments_, segments_fixed_;
-  const urdf::Model& model_;
+  urdf::Model model_;
   tf2_ros::TransformBroadcaster tf_broadcaster_;
   tf2_ros::StaticTransformBroadcaster static_tf_broadcaster_;
 };

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -50,6 +50,20 @@ namespace robot_state_publisher{
   RobotStatePublisher::RobotStatePublisher(const KDL::Tree& tree, const urdf::Model& model)
     : model_(model)
   {
+    init(tree);
+  }
+
+  RobotStatePublisher::RobotStatePublisher()
+    : model_(urdf::Model())
+  {
+    init(KDL::Tree());
+  }
+
+
+
+  void RobotStatePublisher::init(const KDL::Tree& tree, const urdf::Model& model) {
+    // copy constructor
+    model_ = model;
     // walk the tree and add segments to segments_
     addChildren(tree.getRootSegment());
   }

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -65,6 +65,8 @@ namespace robot_state_publisher{
     // copy constructor
     model_ = model;
     // walk the tree and add segments to segments_
+    segments_.clear();
+    segments_fixed_.clear();
     addChildren(tree.getRootSegment());
   }
 

--- a/test/test_init.cpp
+++ b/test/test_init.cpp
@@ -1,0 +1,67 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, Open Source Robotics Foundation, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include <kdl_parser/kdl_parser.hpp>
+#include "robot_state_publisher/robot_state_publisher.h"
+
+TEST(TestRobotStatePubInit, default_constructor)
+{
+  robot_state_publisher::RobotStatePublisher state_pub;
+
+  // Test delayed initialization
+  // Get the robot description and parse the kdl tree
+  urdf::Model model;
+  model.initParam("robot_description");
+  KDL::Tree tree;
+  if (!kdl_parser::treeFromUrdfModel(model, tree)){
+    ROS_ERROR("Failed to extract kdl tree from xml robot description");
+    FAIL();
+  }
+
+  state_pub.init(std::move(tree), std::move(model));
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "test_init");
+  testing::InitGoogleTest(&argc, argv);
+
+  int res = RUN_ALL_TESTS();
+
+  return res;
+}

--- a/test/test_init.cpp
+++ b/test/test_init.cpp
@@ -36,13 +36,15 @@
 
 #include <gtest/gtest.h>
 
+#include <tf2_ros/transform_listener.h>
+#include <geometry_msgs/TransformStamped.h>
+
 #include <kdl_parser/kdl_parser.hpp>
-#include "robot_state_publisher/robot_state_publisher.h"
+#include "robot_state_publisher/joint_state_listener.h"
 
 TEST(TestRobotStatePubInit, default_constructor)
 {
-  robot_state_publisher::RobotStatePublisher state_pub;
-
+  robot_state_publisher::JointStateListener robot_state_pub;
   // Test delayed initialization
   // Get the robot description and parse the kdl tree
   urdf::Model model;
@@ -52,8 +54,36 @@ TEST(TestRobotStatePubInit, default_constructor)
     ROS_ERROR("Failed to extract kdl tree from xml robot description");
     FAIL();
   }
+  ASSERT_EQ(model.links_.size(), 2);
+  ASSERT_EQ(model.joints_.size(), 1);
 
-  state_pub.init(std::move(tree), std::move(model));
+  MimicMap mimic;
+  robot_state_publisher::JointStateListener::constructMimicMap(mimic, model);
+  robot_state_pub.init(tree, mimic, model);
+  ASSERT_EQ(model.links_.size(), 2);
+  ASSERT_EQ(model.joints_.size(), 1);
+
+  tf2_ros::Buffer buffer;
+  tf2_ros::TransformListener listener(buffer);
+
+  // Test that the model has the two links specified
+  ros::NodeHandle n;
+  ros::Publisher js_pub = n.advertise<sensor_msgs::JointState>("joint_states", 10);
+  sensor_msgs::JointState js_msg;
+  js_msg.name.push_back("joint1");
+  js_msg.position.push_back(M_PI);
+
+  js_msg.header.stamp = ros::Time::now();
+  js_pub.publish(js_msg);
+
+  //for (unsigned int i=0; i<100 && !buffer.canTransform("link1", "link2", ros::Time()); i++){
+  while (!buffer.canTransform("link1", "link2", ros::Time())){
+    ros::Duration(0.1).sleep();
+    ros::spinOnce();
+  }
+
+  ASSERT_TRUE(buffer.canTransform("link1", "link2", ros::Time()));
+  ASSERT_FALSE(buffer.canTransform("base_link", "wim_link", ros::Time()));
 }
 
 int main(int argc, char** argv)

--- a/test/test_init.launch
+++ b/test/test_init.launch
@@ -1,8 +1,5 @@
 <launch>
   <param name="robot_description" textfile="$(find robot_state_publisher)/test/one_link.urdf" />
 
-  <!-- node pkg="robot_state_publisher" name="one_link_state_pub" type="robot_state_publisher">
-  </node -->
-
   <test test-name="test_init" pkg="robot_state_publisher" type="test_init" />
 </launch>

--- a/test/test_init.launch
+++ b/test/test_init.launch
@@ -1,5 +1,7 @@
 <launch>
-  <param name="robot_description" textfile="$(find robot_state_publisher)/test/one_link.urdf" />
+  <param name="robot_description"
+         textfile="$(find robot_state_publisher)/test/two_links_moving_joint.urdf" />
+  <param name="use_tf_static" value="false" />
 
-  <test test-name="test_init" pkg="robot_state_publisher" type="test_init" />
+  <test test-name="test_init" pkg="robot_state_publisher" type="test_init"/>
 </launch>

--- a/test/test_init.launch
+++ b/test/test_init.launch
@@ -1,0 +1,8 @@
+<launch>
+  <param name="robot_description" textfile="$(find robot_state_publisher)/test/one_link.urdf" />
+
+  <!-- node pkg="robot_state_publisher" name="one_link_state_pub" type="robot_state_publisher">
+  </node -->
+
+  <test test-name="test_init" pkg="robot_state_publisher" type="test_init" />
+</launch>

--- a/test/test_two_links_moving_joint.cpp
+++ b/test/test_two_links_moving_joint.cpp
@@ -117,7 +117,6 @@ int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   ros::init(argc, argv, "test_two_links_moving_joint");
-  ros::NodeHandle node;
 
   int res = RUN_ALL_TESTS();
 


### PR DESCRIPTION
Potential implementation of the enhancement discussed in #23. The default constructor of `RobotStatePublisher` creates an instance of the class with an empty KDL tree and an empty URDF model. The `init` function is added for delayed initialization of the KDL tree.
