### PR TITLE
Remove use_tf_static and backwards compat. for non-static fixed transforms

### DIFF
--- a/include/robot_state_publisher/robot_state_publisher.h
+++ b/include/robot_state_publisher/robot_state_publisher.h
@@ -76,7 +76,7 @@ public:
    * \param time The time at which the joint positions were recorded
    */
   virtual void publishTransforms(const std::map<std::string, double>& joint_positions, const ros::Time& time, const std::string& tf_prefix);
-  virtual void publishFixedTransforms(const std::string& tf_prefix, bool use_tf_static = false);
+  virtual void publishFixedTransforms(const std::string& tf_prefix);
 
 protected:
   virtual void addChildren(const KDL::SegmentMap::const_iterator segment);

--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -56,8 +56,6 @@ JointStateListener::JointStateListener(const KDL::Tree& tree, const MimicMap& m,
   // set publish frequency
   double publish_freq;
   n_tilde.param("publish_frequency", publish_freq, 50.0);
-  // set whether to use the /tf_static latched static transform broadcaster
-  n_tilde.param("use_tf_static", use_tf_static_, false);
   // get the tf_prefix parameter from the closest namespace
   std::string tf_prefix_key;
   n_tilde.searchParam("tf_prefix", tf_prefix_key);
@@ -69,7 +67,7 @@ JointStateListener::JointStateListener(const KDL::Tree& tree, const MimicMap& m,
 
   // trigger to publish fixed joints
   // if using static transform broadcaster, this will be a oneshot trigger and only run once
-  timer_ = n_tilde.createTimer(publish_interval_, &JointStateListener::callbackFixedJoint, this, use_tf_static_);
+  timer_ = n_tilde.createTimer(publish_interval_, &JointStateListener::callbackFixedJoint, this);
 
 };
 
@@ -80,7 +78,7 @@ JointStateListener::~JointStateListener()
 
 void JointStateListener::callbackFixedJoint(const ros::TimerEvent& e)
 {
-  state_publisher_.publishFixedTransforms(tf_prefix_, use_tf_static_);
+  state_publisher_.publishFixedTransforms(tf_prefix_);
 }
 
 void JointStateListener::callbackJointState(const JointStateConstPtr& state)

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -103,7 +103,7 @@ namespace robot_state_publisher{
   }
 
   // publish fixed transforms
-  void RobotStatePublisher::publishFixedTransforms(const std::string& tf_prefix, bool use_tf_static)
+  void RobotStatePublisher::publishFixedTransforms(const std::string& tf_prefix)
   {
     ROS_DEBUG("Publishing transforms for fixed joints");
     std::vector<geometry_msgs::TransformStamped> tf_transforms;
@@ -117,11 +117,7 @@ namespace robot_state_publisher{
       tf_transform.child_frame_id = tf::resolve(tf_prefix, seg->second.tip);
       tf_transforms.push_back(tf_transform);
     }
-    if(use_tf_static){
-      static_tf_broadcaster_.sendTransform(tf_transforms);
-    }else{
-      tf_broadcaster_.sendTransform(tf_transforms);
-    }
+    static_tf_broadcaster_.sendTransform(tf_transforms);
   }
 
 }


### PR DESCRIPTION
feedback from @paulbovbel, @ros/ros_team, @ros/robot_model all welcome.

I've decided to remove the backwards compatibility for publishing fixed transforms that do not use tf static in Kinetic, since semantically I don't think there should be a difference between different kinds of fixed transforms and static transforms are more efficient.

Tully brought up that the only issue is that static transforms are usually not captured by rosbag recording because they are latched topics. He also mentioned that one or two introspection tools might not be aware of static transforms but wasn't specific about which ones.
