### PR TITLE
Add target_link_libraries for joint_state_listener library + install it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,11 +20,10 @@ link_directories(${orocos_kdl_LIBRARY_DIRS})
 add_library(${PROJECT_NAME}_solver
   src/robot_state_publisher.cpp src/treefksolverposfull_recursive.cpp
 )
-
-add_library(joint_state_listener
-  src/joint_state_listener.cpp)
-
 target_link_libraries(${PROJECT_NAME}_solver ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES})
+
+add_library(joint_state_listener src/joint_state_listener.cpp)
+target_link_libraries(joint_state_listener ${PROJECT_NAME}_solver ${orocos_kdl_LIBRARIES})
 
 add_executable(${PROJECT_NAME} src/joint_state_listener.cpp)
 target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME}_solver ${orocos_kdl_LIBRARIES})
@@ -64,7 +63,7 @@ if (CATKIN_ENABLE_TESTING)
 
 endif()
 
-install(TARGETS ${PROJECT_NAME}_solver ${PROJECT_NAME} state_publisher
+install(TARGETS ${PROJECT_NAME}_solver joint_state_listener ${PROJECT_NAME} state_publisher
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 


### PR DESCRIPTION
I assume it should be installed to let others use the library, but might be mistaken then.
