### PR TITLE
Publish fixed joints over tf_static by default in kinetic

### DIFF
--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -57,7 +57,7 @@ JointStateListener::JointStateListener(const KDL::Tree& tree, const MimicMap& m,
   double publish_freq;
   n_tilde.param("publish_frequency", publish_freq, 50.0);
   // set whether to use the /tf_static latched static transform broadcaster
-  n_tilde.param("use_tf_static", use_tf_static_, false);
+  n_tilde.param("use_tf_static", use_tf_static_, true);
   // get the tf_prefix parameter from the closest namespace
   std::string tf_prefix_key;
   n_tilde.searchParam("tf_prefix", tf_prefix_key);


### PR DESCRIPTION
For some reason the original commit 7d82611 (or a2c021f?) got lost during the kinetic release. The default value of the `use_tf_static` parameter used to be `true` in jade and from the discussion in https://github.com/ros/robot_state_publisher/pull/37 I assume it should have stayed `true` for all future releases.

The erroneous commit that changed it back to `false` is 19294fb. There are several other bogus commits between [1.11.1](https://github.com/ros/robot_state_publisher/commit/1.11.1) and [1.13.0](https://github.com/ros/robot_state_publisher/commit/1.13.0) ([394bed9...54a8523](https://github.com/ros/robot_state_publisher/compare/394bed99e2657d2bfd2519378b2b3def1c157ff6...54a85239e1ca4a1bb24b9b9aad0822022a135928)) which all together have almost no diff except for merged changelogs and appear to be leftovers from a bad rebase session at March 14 in preparation of the kinetic release. I assume most of these commits were never supposed to end up in the jade-devel and kinetic-devel branches nor in the release tags.
### Optional:

I also created a new merge between the last clean releases 1.11.1 and 1.12.1 into indigo and jade from February 22 as [indigo-jade-merge-cleanup](https://github.com/ros/robot_state_publisher/compare/1.12.1...meyerj:indigo-jade-merge-cleanup) in my fork and merged it into the latest jade-devel and kinetic-devel branches. The only other changes beside the `use_tf_static` default value are some missing changelog entries for version 1.11.0 in jade and kinetic releases and some trailing spaces and removed empty lines. Feel free to pull the two devel branches over in order to document the alternative "true" history and to simplify future Git voodoo:
- https://github.com/ros/robot_state_publisher/compare/jade-devel...meyerj:jade-devel
- https://github.com/ros/robot_state_publisher/compare/kinetic-devel...meyerj:kinetic-devel
