### PR TITLE
Use urdf::*ShredPtr instead of boost::shared_ptr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,14 +7,16 @@ find_package(catkin REQUIRED
 )
 find_package(Eigen3 REQUIRED)
 
+find_package(urdfdom_headers 0.4 REQUIRED)
+
 catkin_package(
   LIBRARIES ${PROJECT_NAME}_solver
   INCLUDE_DIRS include
-  DEPENDS roscpp rosconsole rostime tf2_ros tf2_kdl kdl_parser orocos_kdl
+  DEPENDS roscpp rosconsole rostime tf2_ros tf2_kdl kdl_parser orocos_kdl urdfdom_headers
 )
 
 include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS})
-include_directories(include ${catkin_INCLUDE_DIRS} ${orocos_kdl_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${orocos_kdl_INCLUDE_DIRS} ${urdfdom_headers_INCLUDE_DIRS})
 link_directories(${orocos_kdl_LIBRARY_DIRS})
 
 add_library(${PROJECT_NAME}_solver

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(catkin REQUIRED
 )
 find_package(Eigen3 REQUIRED)
 
-find_package(urdfdom_headers 0.4 REQUIRED)
+find_package(urdfdom_headers REQUIRED)
 
 catkin_package(
   LIBRARIES ${PROJECT_NAME}_solver

--- a/include/robot_state_publisher/joint_state_listener.h
+++ b/include/robot_state_publisher/joint_state_listener.h
@@ -38,6 +38,7 @@
 #define JOINT_STATE_LISTENER_H
 
 #include <urdf/model.h>
+#include <urdf_model/types.h>
 #include <kdl/tree.hpp>
 #include <ros/ros.h>
 #include <sensor_msgs/JointState.h>
@@ -48,7 +49,7 @@ using namespace ros;
 using namespace KDL;
 
 typedef boost::shared_ptr<sensor_msgs::JointState const> JointStateConstPtr;
-typedef std::map<std::string, boost::shared_ptr<urdf::JointMimic> > MimicMap;
+typedef std::map<std::string, urdf::JointMimicSharedPtr > MimicMap;
 
 namespace robot_state_publisher{
 

--- a/include/robot_state_publisher/joint_state_listener.h
+++ b/include/robot_state_publisher/joint_state_listener.h
@@ -38,7 +38,6 @@
 #define JOINT_STATE_LISTENER_H
 
 #include <urdf/model.h>
-#include <urdf_model/types.h>
 #include <kdl/tree.hpp>
 #include <ros/ros.h>
 #include <sensor_msgs/JointState.h>

--- a/package.xml
+++ b/package.xml
@@ -32,7 +32,7 @@
   <build_depend>tf</build_depend>
   <build_depend>tf2_ros</build_depend>
   <build_depend>tf2_kdl</build_depend>
-
+  <build_depend version_gte="0.4">liburdfdom-headers-dev</build_depend>
   <run_depend>catkin</run_depend>
   <run_depend>eigen</run_depend>
   <run_depend>kdl_parser</run_depend>

--- a/package.xml
+++ b/package.xml
@@ -32,7 +32,7 @@
   <build_depend>tf</build_depend>
   <build_depend>tf2_ros</build_depend>
   <build_depend>tf2_kdl</build_depend>
-  <build_depend version_gte="0.4">liburdfdom-headers-dev</build_depend>
+  <build_depend>liburdfdom-headers-dev</build_depend>
   <run_depend>catkin</run_depend>
   <run_depend>eigen</run_depend>
   <run_depend>kdl_parser</run_depend>

--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -35,6 +35,7 @@
 /* Author: Wim Meeussen */
 
 #include <urdf/model.h>
+#include <urdf_model/types.h>
 #include <kdl/tree.hpp>
 #include <ros/ros.h>
 #include "robot_state_publisher/robot_state_publisher.h"
@@ -163,7 +164,7 @@ int main(int argc, char** argv)
 
   MimicMap mimic;
 
-  for(std::map< std::string, boost::shared_ptr< urdf::Joint > >::iterator i = model.joints_.begin(); i != model.joints_.end(); i++){
+  for(std::map< std::string, urdf::JointSharedPtr >::iterator i = model.joints_.begin(); i != model.joints_.end(); i++){
     if(i->second->mimic){
       mimic.insert(make_pair(i->first, i->second->mimic));
     }

--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -35,7 +35,6 @@
 /* Author: Wim Meeussen */
 
 #include <urdf/model.h>
-#include <urdf_model/types.h>
 #include <kdl/tree.hpp>
 #include <ros/ros.h>
 #include "robot_state_publisher/robot_state_publisher.h"

--- a/test/test_subclass.cpp
+++ b/test/test_subclass.cpp
@@ -34,6 +34,8 @@
 
 #include <gtest/gtest.h>
 
+#include <urdf_model/types.h>
+
 #include <kdl_parser/kdl_parser.hpp>
 
 #include "robot_state_publisher/joint_state_listener.h"
@@ -82,7 +84,7 @@ TEST(TestRobotStatePubSubclass, robot_state_pub_subclass)
 
   MimicMap mimic;
 
-  for(std::map< std::string, boost::shared_ptr< urdf::Joint > >::iterator i = model.joints_.begin(); i != model.joints_.end(); i++){
+  for(std::map< std::string, urdf::JointSharedPtr >::iterator i = model.joints_.begin(); i != model.joints_.end(); i++){
     if(i->second->mimic){
       mimic.insert(make_pair(i->first, i->second->mimic));
     }

--- a/test/test_subclass.cpp
+++ b/test/test_subclass.cpp
@@ -34,7 +34,7 @@
 
 #include <gtest/gtest.h>
 
-#include <urdf_model/types.h>
+#include <urdf/model.h>
 
 #include <kdl_parser/kdl_parser.hpp>
 


### PR DESCRIPTION
urdfdom_headers uses C++ std::shared_ptr. As it exports it as custom
*SharedPtr type, we can use the to sty compatible.

This also adds a proper dependency for urdfdom-headers
