### PR TITLE
fix cmake eigen3 warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,9 @@ project(robot_state_publisher)
 
 find_package(orocos_kdl REQUIRED)
 find_package(catkin REQUIRED
-  COMPONENTS roscpp rosconsole rostime tf tf2_ros tf2_kdl kdl_parser cmake_modules rostest
+  COMPONENTS roscpp rosconsole rostime tf tf2_ros tf2_kdl kdl_parser rostest
 )
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 catkin_package(
   LIBRARIES ${PROJECT_NAME}_solver
@@ -13,7 +13,7 @@ catkin_package(
   DEPENDS roscpp rosconsole rostime tf2_ros tf2_kdl kdl_parser orocos_kdl
 )
 
-include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS})
+include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS})
 include_directories(include ${catkin_INCLUDE_DIRS} ${orocos_kdl_INCLUDE_DIRS})
 link_directories(${orocos_kdl_LIBRARY_DIRS})
 

--- a/package.xml
+++ b/package.xml
@@ -32,7 +32,6 @@
   <build_depend>tf</build_depend>
   <build_depend>tf2_ros</build_depend>
   <build_depend>tf2_kdl</build_depend>
-  <build_depend>cmake_modules</build_depend>
 
   <run_depend>catkin</run_depend>
   <run_depend>eigen</run_depend>


### PR DESCRIPTION
Fix the warning:

```
CMake Warning at /opt/ros/kinetic/share/cmake_modules/cmake/Modules/FindEigen.cmake:62 (message):
  The FindEigen.cmake Module in the cmake_modules package is deprecated.

  Please use the FindEigen3.cmake Module provided with Eigen.  Change
  instances of find_package(Eigen) to find_package(Eigen3).  Check the
  FindEigen3.cmake Module for the resulting CMake variable names.

Call Stack (most recent call first):
  CMakeLists.txt:8 (find_package)
```
