### PR TITLE
remove undeserved error log for empty JointState.position

### DIFF
--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -88,7 +88,16 @@ void JointStateListener::callbackFixedJoint(const ros::TimerEvent& e)
 void JointStateListener::callbackJointState(const JointStateConstPtr& state)
 {
   if (state->name.size() != state->position.size()){
-    ROS_ERROR("Robot state publisher received an invalid joint state vector");
+    if (state->position.empty()){
+      const int throttleSeconds = 300;
+      ROS_WARN_THROTTLE(throttleSeconds,
+          "Robot state publisher ignored a JointState message about joint(s) "
+          "\"%s\"(,...) whose position member was empty. This message will "
+          "not reappear for %d seconds.", state->name[0].c_str(),
+          throttleSeconds);
+    } else {
+      ROS_ERROR("Robot state publisher ignored an invalid JointState message");
+    }
     return;
   }
 


### PR DESCRIPTION
as per the JointState message doc, the `position` member must be
either empty OR have the same size as the `name` member.

Some background here http://answers.ros.org/question/244796/jointstate-messages-with-heterogeneous-position-and-velocity-sensors/
