### PR TITLE
adding a parameter "ignore_timestamp"

### DIFF
--- a/include/robot_state_publisher/joint_state_listener.h
+++ b/include/robot_state_publisher/joint_state_listener.h
@@ -74,7 +74,8 @@ protected:
   ros::Time last_callback_time_;
   std::map<std::string, ros::Time> last_publish_time_;
   MimicMap mimic_;
-  bool use_tf_static_, ignore_timestamp_;
+  bool use_tf_static_;
+  bool ignore_timestamp_;
 
 };
 }

--- a/include/robot_state_publisher/joint_state_listener.h
+++ b/include/robot_state_publisher/joint_state_listener.h
@@ -74,7 +74,7 @@ protected:
   ros::Time last_callback_time_;
   std::map<std::string, ros::Time> last_publish_time_;
   MimicMap mimic_;
-  bool use_tf_static_;
+  bool use_tf_static_, ignore_timestamp_;
 
 };
 }

--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -58,6 +58,8 @@ JointStateListener::JointStateListener(const KDL::Tree& tree, const MimicMap& m,
   n_tilde.param("publish_frequency", publish_freq, 50.0);
   // set whether to use the /tf_static latched static transform broadcaster
   n_tilde.param("use_tf_static", use_tf_static_, true);
+  // ignore_timestamp_ == true, joins_states messages are accepted, no matter their timestamp
+  n_tilde.param("ignore_timestamp", ignore_timestamp_, false);
   // get the tf_prefix parameter from the closest namespace
   std::string tf_prefix_key;
   n_tilde.searchParam("tf_prefix", tf_prefix_key);
@@ -111,7 +113,7 @@ void JointStateListener::callbackJointState(const JointStateConstPtr& state)
 
 
   // check if we need to publish
-  if (state->header.stamp >= last_published + publish_interval_){
+  if (ignore_timestamp_ || state->header.stamp >= last_published + publish_interval_){
     // get joint positions from state message
     map<string, double> joint_positions;
     for (unsigned int i=0; i<state->name.size(); i++)


### PR DESCRIPTION
Hi,

very often I found the use case of "old" /joint_states published from rosbags, ignored by robot_state_publisher (by design, I know).
I have the feeling that,  instead of remapping the timestamp to the present (as it is usually done), it would be more intuitive to allow robot_state_publisher to just use the last JointState received, ignoring its timestamp.

The default behaviour is the same as it was before, so users should not find any backward-compatibility problem.

Davide
