### PR TITLE
Add tcp_no_delay to joint_states subscriber

### DIFF
--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -66,8 +66,13 @@ JointStateListener::JointStateListener(const KDL::Tree& tree, const MimicMap& m,
   n_tilde.param(tf_prefix_key, tf_prefix_, std::string(""));
   publish_interval_ = ros::Duration(1.0/max(publish_freq, 1.0));
 
+  // Setting no delay to true prevents that some joint_states messages are bundled
+  // and sent in pairs, reducing the period to which we receive new data to half
+  // and causing some tf joints to go at 25Hz instead of 50Hz
+  ros::TransportHints transport_hints;
+  transport_hints.tcpNoDelay(true);
   // subscribe to joint state
-  joint_state_sub_ = n.subscribe("joint_states", 1, &JointStateListener::callbackJointState, this);
+  joint_state_sub_ = n.subscribe("joint_states", 1, &JointStateListener::callbackJointState, this, transport_hints);
 
   // trigger to publish fixed joints
   // if using static transform broadcaster, this will be a oneshot trigger and only run once

--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -66,9 +66,9 @@ JointStateListener::JointStateListener(const KDL::Tree& tree, const MimicMap& m,
   n_tilde.param(tf_prefix_key, tf_prefix_, std::string(""));
   publish_interval_ = ros::Duration(1.0/max(publish_freq, 1.0));
 
-  // Setting no delay to true prevents that some joint_states messages are bundled
-  // and sent in pairs, reducing the period to which we receive new data to half
-  // and causing some tf joints to go at 25Hz instead of 50Hz
+  // Setting tcpNoNelay tells the subscriber to ask publishers that connect
+  // to set TCP_NODELAY on their side. This prevents some joint_state messages
+  // from being bundled together, increasing the latency of one of the messages.
   ros::TransportHints transport_hints;
   transport_hints.tcpNoDelay(true);
   // subscribe to joint state


### PR DESCRIPTION
Setting no delay to true prevents that some joint_states messages are bundled  and sent in pairs, reducing the period to which we receive new data to half and causing some tf joints to go at 25Hz instead of 50Hz.

This can be observed by running `rostopic hz /joint_states`:

> average rate: 49.988
	min: 0.000s max: 0.043s std dev: 0.01929s window: 3552
The std dev is an indicator of how the messages arrive bundled.