### PR TITLE
Remove dependency on tf and tf_prefix support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
 
 find_package(orocos_kdl REQUIRED)
 find_package(catkin REQUIRED
-  COMPONENTS roscpp rosconsole rostime tf tf2_ros tf2_kdl kdl_parser
+  COMPONENTS roscpp rosconsole rostime tf2_ros tf2_kdl kdl_parser
 )
 find_package(Eigen3 REQUIRED)
 

--- a/include/robot_state_publisher/joint_state_listener.h
+++ b/include/robot_state_publisher/joint_state_listener.h
@@ -67,7 +67,6 @@ protected:
   virtual void callbackJointState(const JointStateConstPtr& state);
   virtual void callbackFixedJoint(const ros::TimerEvent& e);
 
-  std::string tf_prefix_;
   Duration publish_interval_;
   robot_state_publisher::RobotStatePublisher state_publisher_;
   Subscriber joint_state_sub_;

--- a/include/robot_state_publisher/robot_state_publisher.h
+++ b/include/robot_state_publisher/robot_state_publisher.h
@@ -39,7 +39,6 @@
 
 #include <ros/ros.h>
 #include <boost/scoped_ptr.hpp>
-#include <tf/tf.h>
 #include <urdf/model.h>
 #include <tf2_ros/static_transform_broadcaster.h>
 #include <tf2_ros/transform_broadcaster.h>
@@ -75,8 +74,8 @@ public:
    * \param joint_positions A map of joint names and joint positions.
    * \param time The time at which the joint positions were recorded
    */
-  virtual void publishTransforms(const std::map<std::string, double>& joint_positions, const ros::Time& time, const std::string& tf_prefix);
-  virtual void publishFixedTransforms(const std::string& tf_prefix, bool use_tf_static = false);
+  virtual void publishTransforms(const std::map<std::string, double>& joint_positions, const ros::Time& time);
+  virtual void publishFixedTransforms(bool use_tf_static = false);
 
 protected:
   virtual void addChildren(const KDL::SegmentMap::const_iterator segment);

--- a/package.xml
+++ b/package.xml
@@ -3,7 +3,7 @@
   <version>1.13.5</version>
   <description>
     This package allows you to publish the state of a robot to
-    <a href="http://ros.org/wiki/tf">tf</a>. Once the state gets published, it is
+    <a href="http://ros.org/wiki/tf2">tf</a>. Once the state gets published, it is
     available to all components in the system that also use <tt>tf</tt>.
     The package takes the joint angles of the robot as input
     and publishes the 3D poses of the robot links, using a kinematic
@@ -32,7 +32,6 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rostime</build_depend>
   <build_depend>sensor_msgs</build_depend>
-  <build_depend>tf</build_depend>
   <build_depend>tf2_ros</build_depend>
   <build_depend>tf2_kdl</build_depend>
   <build_depend>liburdfdom-headers-dev</build_depend>
@@ -44,7 +43,6 @@
   <run_depend>roscpp</run_depend>
   <run_depend>rostime</run_depend>
   <run_depend>sensor_msgs</run_depend>
-  <run_depend>tf</run_depend>
   <run_depend>tf2_ros</run_depend>
   <run_depend>tf2_kdl</run_depend>
 

--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -61,9 +61,6 @@ JointStateListener::JointStateListener(const KDL::Tree& tree, const MimicMap& m,
   // ignore_timestamp_ == true, joins_states messages are accepted, no matter their timestamp
   n_tilde.param("ignore_timestamp", ignore_timestamp_, false);
   // get the tf_prefix parameter from the closest namespace
-  std::string tf_prefix_key;
-  n_tilde.searchParam("tf_prefix", tf_prefix_key);
-  n_tilde.param(tf_prefix_key, tf_prefix_, std::string(""));
   publish_interval_ = ros::Duration(1.0/max(publish_freq, 1.0));
 
   // subscribe to joint state
@@ -82,7 +79,7 @@ JointStateListener::~JointStateListener()
 void JointStateListener::callbackFixedJoint(const ros::TimerEvent& e)
 {
   (void)e;
-  state_publisher_.publishFixedTransforms(tf_prefix_, use_tf_static_);
+  state_publisher_.publishFixedTransforms(use_tf_static_);
 }
 
 void JointStateListener::callbackJointState(const JointStateConstPtr& state)
@@ -134,7 +131,7 @@ void JointStateListener::callbackJointState(const JointStateConstPtr& state)
       }
     }
 
-    state_publisher_.publishTransforms(joint_positions, state->header.stamp, tf_prefix_);
+    state_publisher_.publishTransforms(joint_positions, state->header.stamp);
 
     // store publish time in joint map
     for (unsigned int i = 0; i<state->name.size(); i++) {

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -78,9 +78,17 @@ void RobotStatePublisher::addChildren(const KDL::SegmentMap::const_iterator segm
   }
 }
 
+std::string stripSlash(const std::string & in)
+{
+  if (in.size() && in[0] == '/')
+  {
+    return in.substr(1);
+  }
+  return in;
+}
 
 // publish moving transforms
-void RobotStatePublisher::publishTransforms(const map<string, double>& joint_positions, const Time& time, const std::string& tf_prefix)
+void RobotStatePublisher::publishTransforms(const map<string, double>& joint_positions, const Time& time)
 {
   ROS_DEBUG("Publishing transforms for moving joints");
   std::vector<geometry_msgs::TransformStamped> tf_transforms;
@@ -91,8 +99,8 @@ void RobotStatePublisher::publishTransforms(const map<string, double>& joint_pos
     if (seg != segments_.end()) {
       geometry_msgs::TransformStamped tf_transform = tf2::kdlToTransform(seg->second.segment.pose(jnt->second));
       tf_transform.header.stamp = time;
-      tf_transform.header.frame_id = tf::resolve(tf_prefix, seg->second.root);
-      tf_transform.child_frame_id = tf::resolve(tf_prefix, seg->second.tip);
+      tf_transform.header.frame_id = stripSlash(seg->second.root);
+      tf_transform.child_frame_id = stripSlash(seg->second.tip);
       tf_transforms.push_back(tf_transform);
     }
   }
@@ -100,7 +108,7 @@ void RobotStatePublisher::publishTransforms(const map<string, double>& joint_pos
 }
 
 // publish fixed transforms
-void RobotStatePublisher::publishFixedTransforms(const std::string& tf_prefix, bool use_tf_static)
+void RobotStatePublisher::publishFixedTransforms(bool use_tf_static)
 {
   ROS_DEBUG("Publishing transforms for fixed joints");
   std::vector<geometry_msgs::TransformStamped> tf_transforms;
@@ -113,8 +121,8 @@ void RobotStatePublisher::publishFixedTransforms(const std::string& tf_prefix, b
     if (!use_tf_static) {
       tf_transform.header.stamp += ros::Duration(0.5);
     }
-    tf_transform.header.frame_id = tf::resolve(tf_prefix, seg->second.root);
-    tf_transform.child_frame_id = tf::resolve(tf_prefix, seg->second.tip);
+    tf_transform.header.frame_id = stripSlash(seg->second.root);
+    tf_transform.child_frame_id = stripSlash(seg->second.tip);
     tf_transforms.push_back(tf_transform);
   }
   if (use_tf_static) {


### PR DESCRIPTION
This PR removes the dependency on tf (#79) and the long deprecated tf_prefix. I have not done a prerelease test yet. It is likely the removal of the `tf_prefix` argument will break downstream users of the c++ API.