### PR TITLE
added warning when joint is found in joint message but not in the urdf

### DIFF
--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -95,6 +95,9 @@ void RobotStatePublisher::publishTransforms(const map<string, double>& joint_pos
       tf_transform.child_frame_id = tf::resolve(tf_prefix, seg->second.tip);
       tf_transforms.push_back(tf_transform);
     }
+    else {
+      ROS_WARN_THROTTLE(10,"Joint with name: \"%s\" was in published in JointMessage but not found in URDF description", jnt->first.c_str());
+    }
   }
   tf_broadcaster_.sendTransform(tf_transforms);
 }

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -96,7 +96,7 @@ void RobotStatePublisher::publishTransforms(const map<string, double>& joint_pos
       tf_transforms.push_back(tf_transform);
     }
     else {
-      ROS_WARN_THROTTLE(10,"Joint with name: \"%s\" was in published in JointMessage but not found in URDF description", jnt->first.c_str());
+      ROS_WARN_THROTTLE(10, "Joint state with name: \"%s\" was received but not found in URDF", jnt->first.c_str());
     }
   }
   tf_broadcaster_.sendTransform(tf_transforms);


### PR DESCRIPTION
when the joint message includes a joint which is not found in the URDF, a warning is now displayed. Previously this was only ignored.

Since no transform can be published when no URDF description is provided for the joint, either the URDF is incomplete or the `joint_state_controller` publishes wrong joints.

@SammyRamone
@v4hn