### PR TITLE
Add in a public default constructor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,10 +51,6 @@ target_link_libraries(joint_state_listener ${PROJECT_NAME}_solver ${orocos_kdl_L
 add_executable(${PROJECT_NAME} src/joint_state_listener.cpp)
 target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME}_solver ${orocos_kdl_LIBRARIES})
 
-# compile the same executable using the old name as well
-add_executable(state_publisher src/joint_state_listener.cpp)
-target_link_libraries(state_publisher ${PROJECT_NAME}_solver ${orocos_kdl_LIBRARIES})
-
 # Tests
 
 if (CATKIN_ENABLE_TESTING)
@@ -95,7 +91,7 @@ install(TARGETS ${PROJECT_NAME}_solver joint_state_listener
   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
 
 # Install executable
-install(TARGETS ${PROJECT_NAME} state_publisher
+install(TARGETS ${PROJECT_NAME}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(DIRECTORY include/${PROJECT_NAME}/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,8 @@ target_link_libraries(${PROJECT_NAME}_solver ${catkin_LIBRARIES} ${orocos_kdl_LI
 add_library(joint_state_listener src/joint_state_listener.cpp)
 target_link_libraries(joint_state_listener ${PROJECT_NAME}_solver ${orocos_kdl_LIBRARIES})
 
-add_executable(${PROJECT_NAME} src/joint_state_listener.cpp)
-target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME}_solver ${orocos_kdl_LIBRARIES})
+add_executable(${PROJECT_NAME} src/robot_state_publisher_node.cpp)
+target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME}_solver joint_state_listener ${orocos_kdl_LIBRARIES})
 
 # Tests
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,9 @@ if (CATKIN_ENABLE_TESTING)
 
   find_package(rostest REQUIRED)
 
+  add_rostest_gtest(test_default_constructor test/test_default_constructor.launch test/test_default_constructor.cpp)
+  target_link_libraries(test_default_constructor joint_state_listener ${PROJECT_NAME}_solver)
+
   add_rostest_gtest(test_one_link ${CMAKE_CURRENT_SOURCE_DIR}/test/test_one_link.launch test/test_one_link.cpp)
   target_link_libraries(test_one_link ${catkin_LIBRARIES} ${PROJECT_NAME}_solver)
 

--- a/include/robot_state_publisher/joint_state_listener.h
+++ b/include/robot_state_publisher/joint_state_listener.h
@@ -56,6 +56,10 @@ namespace robot_state_publisher {
 
 class JointStateListener {
 public:
+  /** Default constructor.
+   */
+  JointStateListener();
+
   /** Constructor
    * \param tree The kinematic model of a robot, represented by a KDL Tree
    */

--- a/include/robot_state_publisher/joint_state_listener.h
+++ b/include/robot_state_publisher/joint_state_listener.h
@@ -38,6 +38,8 @@
 #define JOINT_STATE_LISTENER_H
 
 #include <memory>
+#include <map>
+#include <string>
 
 #include <boost/scoped_ptr.hpp>
 #include <urdf/model.h>
@@ -46,10 +48,6 @@
 #include <sensor_msgs/JointState.h>
 
 #include "robot_state_publisher/robot_state_publisher.h"
-
-using namespace std;
-using namespace ros;
-using namespace KDL;
 
 typedef boost::shared_ptr<sensor_msgs::JointState const> JointStateConstPtr;
 typedef std::map<std::string, urdf::JointMimicSharedPtr > MimicMap;
@@ -73,9 +71,9 @@ protected:
   virtual void callbackJointState(const JointStateConstPtr& state);
   virtual void callbackFixedJoint(const ros::TimerEvent& e);
 
-  Duration publish_interval_;
+  ros::Duration publish_interval_;
   std::shared_ptr<RobotStatePublisher> state_publisher_;
-  Subscriber joint_state_sub_;
+  ros::Subscriber joint_state_sub_;
   ros::Timer timer_;
   ros::Time last_callback_time_;
   std::map<std::string, ros::Time> last_publish_time_;

--- a/include/robot_state_publisher/joint_state_listener.h
+++ b/include/robot_state_publisher/joint_state_listener.h
@@ -49,10 +49,10 @@
 
 #include "robot_state_publisher/robot_state_publisher.h"
 
+namespace robot_state_publisher {
+
 typedef boost::shared_ptr<sensor_msgs::JointState const> JointStateConstPtr;
 typedef std::map<std::string, urdf::JointMimicSharedPtr > MimicMap;
-
-namespace robot_state_publisher {
 
 class JointStateListener {
 public:

--- a/include/robot_state_publisher/joint_state_listener.h
+++ b/include/robot_state_publisher/joint_state_listener.h
@@ -39,6 +39,7 @@
 
 #include <memory>
 
+#include <boost/scoped_ptr.hpp>
 #include <urdf/model.h>
 #include <kdl/tree.hpp>
 #include <ros/ros.h>

--- a/include/robot_state_publisher/robot_state_publisher.h
+++ b/include/robot_state_publisher/robot_state_publisher.h
@@ -64,6 +64,10 @@ public:
 class RobotStatePublisher
 {
 public:
+  /** Default constructor.
+   */
+  RobotStatePublisher();
+
   /** Constructor
    * \param tree The kinematic model of a robot, represented by a KDL Tree
    */

--- a/include/robot_state_publisher/robot_state_publisher.h
+++ b/include/robot_state_publisher/robot_state_publisher.h
@@ -37,6 +37,9 @@
 #ifndef ROBOT_STATE_PUBLISHER_H
 #define ROBOT_STATE_PUBLISHER_H
 
+#include <map>
+#include <string>
+
 #include <ros/ros.h>
 #include <urdf/model.h>
 #include <tf2_ros/static_transform_broadcaster.h>

--- a/include/robot_state_publisher/robot_state_publisher.h
+++ b/include/robot_state_publisher/robot_state_publisher.h
@@ -38,7 +38,6 @@
 #define ROBOT_STATE_PUBLISHER_H
 
 #include <ros/ros.h>
-#include <boost/scoped_ptr.hpp>
 #include <urdf/model.h>
 #include <tf2_ros/static_transform_broadcaster.h>
 #include <tf2_ros/transform_broadcaster.h>

--- a/package.xml
+++ b/package.xml
@@ -39,7 +39,9 @@
   <build_depend>liburdfdom-headers-dev</build_depend>
   <build_depend>eigen</build_depend>
 
-  <exec_depend>liborocos-kdl-dev</exec_depend>
+  <build_export_depend>liborocos-kdl-dev</build_export_depend>
+
+  <exec_depend>liborocos-kdl</exec_depend>
 
   <test_depend>rosbag</test_depend>
   <test_depend>rostest</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -1,10 +1,10 @@
-<package>
+<package format="2">
   <name>robot_state_publisher</name>
   <version>1.13.5</version>
   <description>
     This package allows you to publish the state of a robot to
-    <a href="http://ros.org/wiki/tf2">tf</a>. Once the state gets published, it is
-    available to all components in the system that also use <tt>tf</tt>.
+    <a href="http://ros.org/wiki/tf2">tf2</a>. Once the state gets published, it is
+    available to all components in the system that also use <tt>tf2</tt>.
     The package takes the joint angles of the robot as input
     and publishes the 3D poses of the robot links, using a kinematic
     tree model of the robot. The package can both be used as a library
@@ -26,28 +26,21 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>eigen</build_depend>
-  <build_depend>kdl_parser</build_depend>
+  <depend>kdl_parser</depend>
+  <depend>rosconsole</depend>
+  <depend>roscpp</depend>
+  <depend>rostime</depend>
+  <depend>sensor_msgs</depend>
+  <depend>tf</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_kdl</depend>
+
   <build_depend>liborocos-kdl-dev</build_depend>
-  <build_depend>rosconsole</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>rostime</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>tf2_ros</build_depend>
-  <build_depend>tf2_kdl</build_depend>
   <build_depend>liburdfdom-headers-dev</build_depend>
-  <run_depend>catkin</run_depend>
-  <run_depend>eigen</run_depend>
-  <run_depend>kdl_parser</run_depend>
-  <run_depend>liborocos-kdl-dev</run_depend>
-  <run_depend>rosconsole</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>rostime</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>tf2_ros</run_depend>
-  <run_depend>tf2_kdl</run_depend>
+  <build_depend>eigen</build_depend>
+
+  <exec_depend>liborocos-kdl-dev</exec_depend>
 
   <test_depend>rosbag</test_depend>
-
   <test_depend>rostest</test_depend>
 </package>

--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -47,6 +47,10 @@
 
 using namespace robot_state_publisher;
 
+JointStateListener::JointStateListener() : JointStateListener(KDL::Tree(), MimicMap())
+{
+}
+
 JointStateListener::JointStateListener(const KDL::Tree& tree, const MimicMap& m, const urdf::Model& model)
   : JointStateListener(std::make_shared<RobotStatePublisher>(tree, model), m)
 {

--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -34,6 +34,9 @@
 
 /* Author: Wim Meeussen */
 
+#include <map>
+#include <string>
+
 #include <ros/ros.h>
 #include <urdf/model.h>
 #include <kdl/tree.hpp>
@@ -42,9 +45,6 @@
 #include "robot_state_publisher/robot_state_publisher.h"
 #include "robot_state_publisher/joint_state_listener.h"
 
-using namespace std;
-using namespace ros;
-using namespace KDL;
 using namespace robot_state_publisher;
 
 JointStateListener::JointStateListener(const KDL::Tree& tree, const MimicMap& m, const urdf::Model& model)
@@ -66,7 +66,7 @@ JointStateListener::JointStateListener(const std::shared_ptr<RobotStatePublisher
   // ignore_timestamp_ == true, joins_states messages are accepted, no matter their timestamp
   n_tilde.param("ignore_timestamp", ignore_timestamp_, false);
   // get the tf_prefix parameter from the closest namespace
-  publish_interval_ = ros::Duration(1.0/max(publish_freq, 1.0));
+  publish_interval_ = ros::Duration(1.0/std::max(publish_freq, 1.0));
 
   // Setting tcpNoNelay tells the subscriber to ask publishers that connect
   // to set TCP_NODELAY on their side. This prevents some joint_state messages
@@ -123,7 +123,7 @@ void JointStateListener::callbackJointState(const JointStateConstPtr& state)
 
   // determine least recently published joint
   ros::Time last_published = now;
-  for (unsigned int i=0; i<state->name.size(); i++) {
+  for (unsigned int i = 0; i < state->name.size(); i++) {
     ros::Time t = last_publish_time_[state->name[i]];
     last_published = (t < last_published) ? t : last_published;
   }
@@ -133,8 +133,8 @@ void JointStateListener::callbackJointState(const JointStateConstPtr& state)
   // check if we need to publish
   if (ignore_timestamp_ || state->header.stamp >= last_published + publish_interval_) {
     // get joint positions from state message
-    map<string, double> joint_positions;
-    for (unsigned int i=0; i<state->name.size(); i++) {
+    std::map<std::string, double> joint_positions;
+    for (unsigned int i = 0; i < state->name.size(); i++) {
       joint_positions.insert(make_pair(state->name[i], state->position[i]));
     }
 
@@ -161,7 +161,7 @@ int main(int argc, char** argv)
 {
   // Initialize ros
   ros::init(argc, argv, "robot_state_publisher");
-  NodeHandle node;
+  ros::NodeHandle node;
 
   ///////////////////////////////////////// begin deprecation warning
   std::string exe_name = argv[0];

--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -128,7 +128,7 @@ void JointStateListener::callbackJointState(const JointStateConstPtr& state)
 
   // determine least recently published joint
   ros::Time last_published = now;
-  for (unsigned int i = 0; i < state->name.size(); i++) {
+  for (size_t i = 0; i < state->name.size(); ++i) {
     ros::Time t = last_publish_time_[state->name[i]];
     last_published = (t < last_published) ? t : last_published;
   }
@@ -139,7 +139,7 @@ void JointStateListener::callbackJointState(const JointStateConstPtr& state)
   if (ignore_timestamp_ || state->header.stamp >= last_published + publish_interval_) {
     // get joint positions from state message
     std::map<std::string, double> joint_positions;
-    for (unsigned int i = 0; i < state->name.size(); i++) {
+    for (size_t i = 0; i < state->name.size(); ++i) {
       joint_positions.insert(make_pair(state->name[i], state->position[i]));
     }
 
@@ -153,7 +153,7 @@ void JointStateListener::callbackJointState(const JointStateConstPtr& state)
     state_publisher_->publishTransforms(joint_positions, state->header.stamp);
 
     // store publish time in joint map
-    for (unsigned int i = 0; i<state->name.size(); i++) {
+    for (size_t i = 0; i<state->name.size(); ++i) {
       last_publish_time_[state->name[i]] = state->header.stamp;
     }
   }

--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -153,37 +153,3 @@ void JointStateListener::callbackJointState(const JointStateConstPtr& state)
     }
   }
 }
-
-// ----------------------------------
-// ----- MAIN -----------------------
-// ----------------------------------
-int main(int argc, char** argv)
-{
-  // Initialize ros
-  ros::init(argc, argv, "robot_state_publisher");
-  ros::NodeHandle node;
-
-  // gets the location of the robot description on the parameter server
-  urdf::Model model;
-  if (!model.initParam("robot_description"))
-    return 1;
-
-  KDL::Tree tree;
-  if (!kdl_parser::treeFromUrdfModel(model, tree)) {
-    ROS_ERROR("Failed to extract kdl tree from xml robot description");
-    return 1;
-  }
-
-  MimicMap mimic;
-
-  for(std::map< std::string, urdf::JointSharedPtr >::iterator i = model.joints_.begin(); i != model.joints_.end(); i++) {
-    if(i->second->mimic) {
-      mimic.insert(make_pair(i->first, i->second->mimic));
-    }
-  }
-
-  JointStateListener state_publisher(tree, mimic, model);
-  ros::spin();
-
-  return 0;
-}

--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -34,6 +34,7 @@
 
 /* Author: Wim Meeussen */
 
+#include <algorithm>
 #include <map>
 #include <string>
 

--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -163,17 +163,6 @@ int main(int argc, char** argv)
   ros::init(argc, argv, "robot_state_publisher");
   ros::NodeHandle node;
 
-  ///////////////////////////////////////// begin deprecation warning
-  std::string exe_name = argv[0];
-  std::size_t slash = exe_name.find_last_of("/");
-  if (slash != std::string::npos) {
-    exe_name = exe_name.substr(slash + 1);
-  }
-  if (exe_name == "state_publisher") {
-    ROS_WARN("The 'state_publisher' executable is deprecated. Please use 'robot_state_publisher' instead");
-  }
-  ///////////////////////////////////////// end deprecation warning
-
   // gets the location of the robot description on the parameter server
   urdf::Model model;
   if (!model.initParam("robot_description"))

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -46,6 +46,10 @@
 
 namespace robot_state_publisher {
 
+RobotStatePublisher::RobotStatePublisher() : RobotStatePublisher(KDL::Tree())
+{
+}
+
 RobotStatePublisher::RobotStatePublisher(const KDL::Tree& tree, const urdf::Model& model)
   : model_(model)
 {

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -37,6 +37,7 @@
 #include <kdl/frames_io.hpp>
 #include <geometry_msgs/TransformStamped.h>
 #include <tf2_kdl/tf2_kdl.h>
+#include <tf/tf.h>
 
 #include "robot_state_publisher/robot_state_publisher.h"
 

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -34,15 +34,15 @@
 
 /* Author: Wim Meeussen */
 
+#include <map>
+#include <string>
+
 #include <kdl/frames_io.hpp>
 #include <geometry_msgs/TransformStamped.h>
 #include <tf2_kdl/tf2_kdl.h>
 #include <tf/tf.h>
 
 #include "robot_state_publisher/robot_state_publisher.h"
-
-using namespace std;
-using namespace ros;
 
 namespace robot_state_publisher {
 
@@ -59,7 +59,7 @@ void RobotStatePublisher::addChildren(const KDL::SegmentMap::const_iterator segm
   const std::string& root = GetTreeElementSegment(segment->second).getName();
 
   const std::vector<KDL::SegmentMap::const_iterator>& children = GetTreeElementChildren(segment->second);
-  for (unsigned int i=0; i<children.size(); i++) {
+  for (unsigned int i = 0; i < children.size(); ++i) {
     const KDL::Segment& child = GetTreeElementSegment(children[i]->second);
     SegmentPair s(GetTreeElementSegment(children[i]->second), root, child.getName());
     if (child.getJoint().getType() == KDL::Joint::None) {
@@ -89,13 +89,13 @@ std::string stripSlash(const std::string & in)
 }
 
 // publish moving transforms
-void RobotStatePublisher::publishTransforms(const map<string, double>& joint_positions, const Time& time)
+void RobotStatePublisher::publishTransforms(const std::map<std::string, double>& joint_positions, const ros::Time& time)
 {
   ROS_DEBUG("Publishing transforms for moving joints");
   std::vector<geometry_msgs::TransformStamped> tf_transforms;
 
   // loop over all joints
-  for (map<string, double>::const_iterator jnt=joint_positions.begin(); jnt != joint_positions.end(); jnt++) {
+  for (std::map<std::string, double>::const_iterator jnt = joint_positions.begin(); jnt != joint_positions.end(); jnt++) {
     std::map<std::string, SegmentPair>::const_iterator seg = segments_.find(jnt->first);
     if (seg != segments_.end()) {
       geometry_msgs::TransformStamped tf_transform = tf2::kdlToTransform(seg->second.segment.pose(jnt->second));
@@ -119,7 +119,7 @@ void RobotStatePublisher::publishFixedTransforms(bool use_tf_static)
   geometry_msgs::TransformStamped tf_transform;
 
   // loop over all fixed segments
-  for (map<string, SegmentPair>::const_iterator seg=segments_fixed_.begin(); seg != segments_fixed_.end(); seg++) {
+  for (std::map<std::string, SegmentPair>::const_iterator seg = segments_fixed_.begin(); seg != segments_fixed_.end(); seg++) {
     geometry_msgs::TransformStamped tf_transform = tf2::kdlToTransform(seg->second.segment.pose(0));
     tf_transform.header.stamp = ros::Time::now();
     if (!use_tf_static) {

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -40,7 +40,6 @@
 #include <kdl/frames_io.hpp>
 #include <geometry_msgs/TransformStamped.h>
 #include <tf2_kdl/tf2_kdl.h>
-#include <tf/tf.h>
 
 #include "robot_state_publisher/robot_state_publisher.h"
 

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -62,7 +62,7 @@ void RobotStatePublisher::addChildren(const KDL::SegmentMap::const_iterator segm
   const std::string& root = GetTreeElementSegment(segment->second).getName();
 
   const std::vector<KDL::SegmentMap::const_iterator>& children = GetTreeElementChildren(segment->second);
-  for (unsigned int i = 0; i < children.size(); ++i) {
+  for (size_t i = 0; i < children.size(); ++i) {
     const KDL::Segment& child = GetTreeElementSegment(children[i]->second);
     SegmentPair s(GetTreeElementSegment(children[i]->second), root, child.getName());
     if (child.getJoint().getType() == KDL::Joint::None) {

--- a/src/robot_state_publisher_node.cpp
+++ b/src/robot_state_publisher_node.cpp
@@ -1,0 +1,78 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2008, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#include <map>
+#include <string>
+
+#include <ros/ros.h>
+#include <urdf/model.h>
+#include <kdl/tree.hpp>
+#include <kdl_parser/kdl_parser.hpp>
+
+#include "robot_state_publisher/robot_state_publisher.h"
+#include "robot_state_publisher/joint_state_listener.h"
+
+// ----------------------------------
+// ----- MAIN -----------------------
+// ----------------------------------
+int main(int argc, char** argv)
+{
+  // Initialize ros
+  ros::init(argc, argv, "robot_state_publisher");
+  ros::NodeHandle node;
+
+  // gets the location of the robot description on the parameter server
+  urdf::Model model;
+  if (!model.initParam("robot_description"))
+    return 1;
+
+  KDL::Tree tree;
+  if (!kdl_parser::treeFromUrdfModel(model, tree)) {
+    ROS_ERROR("Failed to extract kdl tree from xml robot description");
+    return 1;
+  }
+
+  MimicMap mimic;
+
+  for(std::map< std::string, urdf::JointSharedPtr >::iterator i = model.joints_.begin(); i != model.joints_.end(); i++) {
+    if(i->second->mimic) {
+      mimic.insert(make_pair(i->first, i->second->mimic));
+    }
+  }
+
+  robot_state_publisher::JointStateListener state_publisher(tree, mimic, model);
+  ros::spin();
+
+  return 0;
+}

--- a/src/robot_state_publisher_node.cpp
+++ b/src/robot_state_publisher_node.cpp
@@ -34,6 +34,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 
 #include <ros/ros.h>
 #include <urdf/model.h>

--- a/src/robot_state_publisher_node.cpp
+++ b/src/robot_state_publisher_node.cpp
@@ -63,7 +63,7 @@ int main(int argc, char** argv)
     return 1;
   }
 
-  MimicMap mimic;
+  robot_state_publisher::MimicMap mimic;
 
   for(std::map< std::string, urdf::JointSharedPtr >::iterator i = model.joints_.begin(); i != model.joints_.end(); i++) {
     if(i->second->mimic) {

--- a/src/robot_state_publisher_node.cpp
+++ b/src/robot_state_publisher_node.cpp
@@ -68,7 +68,7 @@ int main(int argc, char** argv)
 
   for(std::map< std::string, urdf::JointSharedPtr >::iterator i = model.joints_.begin(); i != model.joints_.end(); i++) {
     if(i->second->mimic) {
-      mimic.insert(make_pair(i->first, i->second->mimic));
+      mimic.insert(std::make_pair(i->first, i->second->mimic));
     }
   }
 

--- a/src/robot_state_publisher_node.cpp
+++ b/src/robot_state_publisher_node.cpp
@@ -66,7 +66,7 @@ int main(int argc, char** argv)
 
   robot_state_publisher::MimicMap mimic;
 
-  for(std::map< std::string, urdf::JointSharedPtr >::iterator i = model.joints_.begin(); i != model.joints_.end(); i++) {
+  for (std::map< std::string, urdf::JointSharedPtr >::iterator i = model.joints_.begin(); i != model.joints_.end(); i++) {
     if (i->second->mimic) {
       mimic.insert(std::make_pair(i->first, i->second->mimic));
     }

--- a/src/robot_state_publisher_node.cpp
+++ b/src/robot_state_publisher_node.cpp
@@ -67,7 +67,7 @@ int main(int argc, char** argv)
   robot_state_publisher::MimicMap mimic;
 
   for(std::map< std::string, urdf::JointSharedPtr >::iterator i = model.joints_.begin(); i != model.joints_.end(); i++) {
-    if(i->second->mimic) {
+    if (i->second->mimic) {
       mimic.insert(std::make_pair(i->first, i->second->mimic));
     }
   }

--- a/test/test_default_constructor.cpp
+++ b/test/test_default_constructor.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
 * Software License Agreement (BSD License)
 *
-*  Copyright (c) 2008, Willow Garage, Inc.
+*  Copyright (c) 2020, Open Source Robotics Foundation, Inc.
 *  All rights reserved.
 *
 *  Redistribution and use in source and binary forms, with or without
@@ -32,66 +32,50 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-/* Author: Wim Meeussen */
 
-#ifndef ROBOT_STATE_PUBLISHER_H
-#define ROBOT_STATE_PUBLISHER_H
-
-#include <map>
 #include <string>
+#include <utility>
 
+#include <gtest/gtest.h>
 #include <ros/ros.h>
-#include <urdf/model.h>
-#include <tf2_ros/static_transform_broadcaster.h>
-#include <tf2_ros/transform_broadcaster.h>
-#include <kdl/frames.hpp>
-#include <kdl/segment.hpp>
-#include <kdl/tree.hpp>
 
-namespace robot_state_publisher {
+#include "robot_state_publisher/joint_state_listener.h"
 
-class SegmentPair
+
+TEST(RobotStatePublisher, default_constructor)
 {
-public:
-  SegmentPair(const KDL::Segment& p_segment, const std::string& p_root, const std::string& p_tip):
-    segment(p_segment), root(p_root), tip(p_tip){}
-
-  KDL::Segment segment;
-  std::string root, tip;
-};
-
-
-class RobotStatePublisher
-{
-public:
-  /** Default constructor.
-   */
-  RobotStatePublisher();
-
-  /** Constructor
-   * \param tree The kinematic model of a robot, represented by a KDL Tree
-   */
-  RobotStatePublisher(const KDL::Tree& tree, const urdf::Model& model = urdf::Model());
-
-  /// Destructor
-  ~RobotStatePublisher(){};
-
-  /** Publish transforms to tf
-   * \param joint_positions A map of joint names and joint positions.
-   * \param time The time at which the joint positions were recorded
-   */
-  virtual void publishTransforms(const std::map<std::string, double>& joint_positions, const ros::Time& time);
-  virtual void publishFixedTransforms(bool use_tf_static = false);
-
-protected:
-  virtual void addChildren(const KDL::SegmentMap::const_iterator segment);
-
-  std::map<std::string, SegmentPair> segments_, segments_fixed_;
-  urdf::Model model_;
-  tf2_ros::TransformBroadcaster tf_broadcaster_;
-  tf2_ros::StaticTransformBroadcaster static_tf_broadcaster_;
-};
-
+  robot_state_publisher::RobotStatePublisher();
 }
 
-#endif
+TEST(RobotStatePublisher, assignment)
+{
+  robot_state_publisher::RobotStatePublisher rsp;
+
+  urdf::Model model;
+  KDL::Tree tree;
+  rsp = std::move(robot_state_publisher::RobotStatePublisher(tree, model));
+}
+
+TEST(JointStateListener, default_constructor)
+{
+  robot_state_publisher::JointStateListener();
+}
+
+TEST(JointStateListener, assignment)
+{
+  robot_state_publisher::JointStateListener jsl;
+
+  urdf::Model model;
+  KDL::Tree tree;
+
+  jsl = std::move(robot_state_publisher::JointStateListener(
+    tree, robot_state_publisher::MimicMap(), model));
+}
+
+int main(int argc, char ** argv)
+{
+  ros::init(argc, argv, "test_default_constructor");
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+

--- a/test/test_default_constructor.cpp
+++ b/test/test_default_constructor.cpp
@@ -41,12 +41,6 @@
 
 #include "robot_state_publisher/joint_state_listener.h"
 
-
-TEST(RobotStatePublisher, default_constructor)
-{
-  robot_state_publisher::RobotStatePublisher();
-}
-
 TEST(RobotStatePublisher, assignment)
 {
   robot_state_publisher::RobotStatePublisher rsp;
@@ -54,11 +48,6 @@ TEST(RobotStatePublisher, assignment)
   urdf::Model model;
   KDL::Tree tree;
   rsp = std::move(robot_state_publisher::RobotStatePublisher(tree, model));
-}
-
-TEST(JointStateListener, default_constructor)
-{
-  robot_state_publisher::JointStateListener();
 }
 
 TEST(JointStateListener, assignment)

--- a/test/test_default_constructor.launch
+++ b/test/test_default_constructor.launch
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<launch>
+  <param name="robot_description" textfile="$(find robot_state_publisher)/test/one_link.urdf" />
+
+  <test test-name="test_default_constructor" pkg="robot_state_publisher" type="test_default_constructor" />
+</launch>

--- a/test/test_subclass.cpp
+++ b/test/test_subclass.cpp
@@ -47,7 +47,7 @@ class AccessibleJointStateListener : public robot_state_publisher::JointStateLis
 {
 public:
   AccessibleJointStateListener(
-    const KDL::Tree& tree, const MimicMap& m, const urdf::Model& model) :
+    const KDL::Tree& tree, const robot_state_publisher::MimicMap& m, const urdf::Model& model) :
       robot_state_publisher::JointStateListener(tree, m, model)
   {
   }
@@ -82,7 +82,7 @@ TEST(TestRobotStatePubSubclass, robot_state_pub_subclass)
     FAIL();
   }
 
-  MimicMap mimic;
+  robot_state_publisher::MimicMap mimic;
 
   for(std::map< std::string, urdf::JointSharedPtr >::iterator i = model.joints_.begin(); i != model.joints_.end(); i++){
     if(i->second->mimic){

--- a/test/test_two_links_moving_joint.cpp
+++ b/test/test_two_links_moving_joint.cpp
@@ -111,7 +111,6 @@ int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   ros::init(argc, argv, "test_two_links_moving_joint");
-  ros::NodeHandle node;
 
   int res = RUN_ALL_TESTS();
 

--- a/test/test_two_links_moving_joint.launch
+++ b/test/test_two_links_moving_joint.launch
@@ -2,7 +2,7 @@
   <param name="robot_description"
          textfile="$(find robot_state_publisher)/test/two_links_moving_joint.urdf" />
 
-  <node pkg="robot_state_publisher" name="two_links_moving_joints_pub" type="state_publisher">
+  <node pkg="robot_state_publisher" name="two_links_moving_joints_pub" type="robot_state_publisher">
   </node>
 
   <test test-name="test_two_links_moving_joint" pkg="robot_state_publisher" type="test_two_links_moving_joint" />


### PR DESCRIPTION
This should fix #23, and obsoletes #43 .  This PR does a number of things:

1.  It pushes the remaining TF dependency as deeply as possible.  To completely get rid of TF would mean we would have to get rid of the `tf_prefix` functionality.
1.  It moves the include of `boost::shared_ptr` over to the one place it is needed.  We basically can't get rid of this use of boost, since it is what is returned in the callback.
1.  It does some cleanup of namespaces.
1.  It switches the package to package format 2.
1.  It removes the deprecated name of `robot_state_publisher` (`state_publisher`).  That's been deprecated since a commit in 2012, so it is probably safe to remove.
1.  It splits the `main` out from the `joint_state_listener.cpp` file and into its own file.  This makes it so that `JointStateListener` could be used as a library on its own now.
1.  It adds in public default constructors for both `RobotStatePublisher` and `JointStateListener`.

It is easiest to review this PR on a commit-by-commit basis, since the individual commits all make sense.  Let me know if you'd prefer me to split this up into separate PRs.