### PR TITLE
Check for private robot_description

### DIFF
--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -170,9 +170,13 @@ int main(int argc, char** argv)
   ///////////////////////////////////////// end deprecation warning
 
   // gets the location of the robot description on the parameter server
+  // check private then namespace parameter
   urdf::Model model;
-  if (!model.initParam("robot_description"))
-    return -1;
+  if (!model.initParamWithNodeHandle("robot_description", NodeHandle("~")))
+  {
+    if (!model.initParam("robot_description"))
+      return -1;
+  }
 
   KDL::Tree tree;
   if (!kdl_parser::treeFromUrdfModel(model, tree)) {


### PR DESCRIPTION
Hi, 

I came across a use case where I want robot_state_publisher to use its own version of URDF (namely: without meshes as they are loaded with absolute pathes which can lead to unfound mesh files when using several robots).
A solution is to run robot_state_publisher in its own namespace, another is to allow a private robot_description parameter to be used.

If you find any interest in this PR then feel free to merge, otherwise I'll use my fork on our system.