### PR TITLE
Changed node returned error code since its considered reserved

### DIFF
--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -172,12 +172,12 @@ int main(int argc, char** argv)
   // gets the location of the robot description on the parameter server
   urdf::Model model;
   if (!model.initParam("robot_description"))
-    return -1;
+    return 1;
 
   KDL::Tree tree;
   if (!kdl_parser::treeFromUrdfModel(model, tree)) {
     ROS_ERROR("Failed to extract kdl tree from xml robot description");
-    return -1;
+    return 1;
   }
 
   MimicMap mimic;


### PR DESCRIPTION
Whenever robot_state_publisher node fails to parse URDF file it exits with error code -1/255 which is considered a reserved bash exit code(exit status out of range), changed to 1.