### PR TITLE
update how compiler flags are added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,15 @@
 cmake_minimum_required(VERSION 2.8)
 project(robot_state_publisher)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-std=c++11" COMPILER_SUPPORTS_CXX11)
+if(COMPILER_SUPPORTS_CXX11)
+  add_compile_options(-std=c++11)
+  if (NOT WIN32)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")  
+  endif()
+endif()
+
 
 find_package(orocos_kdl REQUIRED)
 find_package(catkin REQUIRED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,13 @@
 cmake_minimum_required(VERSION 2.8)
 project(robot_state_publisher)
 
-include(CheckCXXCompilerFlag)
-check_cxx_compiler_flag("-std=c++11" COMPILER_SUPPORTS_CXX11)
-if (COMPILER_SUPPORTS_CXX11)
-  add_compile_options(-std=c++11)
-  if (NOT WIN32)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")  
-  endif()
+add_compile_options(-std=c++11)
+if (MSVC)
+  # MSVC does not support -Wextra
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Wall")
+else()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 endif()
-
 
 find_package(orocos_kdl REQUIRED)
 find_package(catkin REQUIRED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,25 @@
 cmake_minimum_required(VERSION 2.8)
 project(robot_state_publisher)
 
-add_compile_options(-std=c++11)
-if (MSVC)
-  # MSVC does not support -Wextra
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Wall")
+include(CheckCXXCompilerFlag)
+unset(COMPILER_SUPPORTS_CXX11 CACHE)
+if(MSVC)
+  # https://docs.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version
+  # MSVC will fail the following check since it does not have the c++11 switch
+  # however, c++11 is always enabled (the newer /std:c++14 is enabled by default)
+  check_cxx_compiler_flag(/std:c++11 COMPILER_SUPPORTS_CXX11)
+  if(COMPILER_SUPPORTS_CXX11)
+    add_compile_options(/std:c++11)
+  endif()
+
+  # MSVC does not support the Wextra flag
+  add_compile_options(/Wall)
 else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+  check_cxx_compiler_flag(-std=c++11 COMPILER_SUPPORTS_CXX11)
+  if(COMPILER_SUPPORTS_CXX11)
+    add_compile_options(-std=c++11)
+  endif()
+  add_compile_options(-Wall -Wextra)
 endif()
 
 find_package(orocos_kdl REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(robot_state_publisher)
 
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-std=c++11" COMPILER_SUPPORTS_CXX11)
-if(COMPILER_SUPPORTS_CXX11)
+if (COMPILER_SUPPORTS_CXX11)
   add_compile_options(-std=c++11)
   if (NOT WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")  


### PR DESCRIPTION
update how `c++11` compiler flag is added:
- only add it when it's supported (tested on Ubuntu 18.04)
- add similar logic for MSVC (as mentioned in the comment, this check would fail, but c++11 is always enabled). this pattern could be helpful if later this project moves to c++14 (which is an available switch in MSVC)

the other way to do this is to use `target_compile_features(mylib PUBLIC cxx_std_11)` from [cmake](https://cmake.org/cmake/help/v3.8/manual/cmake-compile-features.7.html#requiring-language-standards), but this would mean to add this line for every target. would this be preferred instead of adding a global `c++11` flag?

there shouldn't be too much difference between `add_compile_options` and `set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} xxx")`, yet here are some discussions regarding the difference between the two: https://stackoverflow.com/questions/39501481/difference-between-add-compile-options-and-setcmake-cxx-flags. personally `add_compile_options` is preferred since it offers a clearer scope and better readability