### PR TITLE
make use_tf_static false by default

### DIFF
--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -57,7 +57,7 @@ JointStateListener::JointStateListener(const KDL::Tree& tree, const MimicMap& m,
   double publish_freq;
   n_tilde.param("publish_frequency", publish_freq, 50.0);
   // set whether to use the /tf_static latched static transform broadcaster
-  n_tilde.param("use_tf_static", use_tf_static_, true);
+  n_tilde.param("use_tf_static", use_tf_static_, false);
   // ignore_timestamp_ == true, joins_states messages are accepted, no matter their timestamp
   n_tilde.param("ignore_timestamp", ignore_timestamp_, false);
   // get the tf_prefix parameter from the closest namespace


### PR DESCRIPTION
This PR reverts the behaviour of the static transform publisher and sets `use_tf_static` to false by default. The main reason for this is to fix the inconsistent behaviour when replaying latched static transforms.
When static transforms are published latched to `tf_static`, it is not possible to "joint" the stream of transformations at a later point.
E.g. it is not possible to recreate the complete state of a robot static transforms if replayed with  `rosbag play <file>.bag -s 10 -k` or when a transform listener is started after replaying the bagfile (see also: https://github.com/ros/robot_state_publisher/issues/105). Another issue is that the latching attribute is not preserved when post-processing a bagfile.

Additionally, this aligns with the settings in `RobotStatePublisher`:
https://github.com/ros/robot_state_publisher/blob/316ee45abe5a6bccf37d15e38b68eda99eb5158d/include/robot_state_publisher/robot_state_publisher.h#L78


Fixes #105 .