### PR TITLE
Add joint_state_listener to the catkin package LIBRARIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(Eigen3 REQUIRED)
 find_package(urdfdom_headers REQUIRED)
 
 catkin_package(
-  LIBRARIES ${PROJECT_NAME}_solver
+  LIBRARIES ${PROJECT_NAME}_solver joint_state_listener
   INCLUDE_DIRS include
   DEPENDS roscpp rosconsole rostime tf2_ros tf2_kdl kdl_parser orocos_kdl urdfdom_headers
 )


### PR DESCRIPTION
The joint_state_listener library was missing from the catkin_package libraries. As a consequence, one cannot to link against it from another package, without resorting to workarounds.

I just added it to the LIBRARIES section of the catkin_package macro