### PR TITLE
[Dashing] publish description right away.

### DIFF
--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -88,6 +88,12 @@ RobotStatePublisher::RobotStatePublisher(
     "robot_description",
     // Transient local is similar to latching in ROS 1.
     rclcpp::QoS(1).transient_local());
+
+  // Publish the robot description, as necessary
+  if (!description_published_) {
+    description_pub_->publish(model_xml_);
+    description_published_ = true;
+  }
 }
 
 // add children to correct maps
@@ -143,12 +149,6 @@ void RobotStatePublisher::publishTransforms(
     }
   }
   tf_broadcaster_.sendTransform(tf_transforms);
-
-  // Publish the robot description, as necessary
-  if (!description_published_) {
-    description_pub_->publish(model_xml_);
-    description_published_ = true;
-  }
 }
 
 // publish fixed transforms

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -76,7 +76,7 @@ RobotStatePublisher::RobotStatePublisher(
 : model_(model),
   tf_broadcaster_(node_handle),
   static_tf_broadcaster_(node_handle),
-  description_published_(false),
+  description_published_(true),
   clock_(node_handle->get_clock())
 {
   // walk the tree and add segments to segments_
@@ -89,11 +89,8 @@ RobotStatePublisher::RobotStatePublisher(
     // Transient local is similar to latching in ROS 1.
     rclcpp::QoS(1).transient_local());
 
-  // Publish the robot description, as necessary
-  if (!description_published_) {
-    description_pub_->publish(model_xml_);
-    description_published_ = true;
-  }
+  // Publish the robot description immediately
+  description_pub_->publish(model_xml_);
 }
 
 // add children to correct maps


### PR DESCRIPTION
I tested and can confirm it fixes ros2/rviz#476. With this PR I see the robot model display regardless of the order I launch RViz or robot_state_publisher.

I left the `description_published_` member to avoid breaking ABI, but it's now unused.