### PR TITLE
Add paramter back in for tf_prefix in robot_state_publisher

### DIFF
--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -77,10 +77,11 @@ JointStateListener::JointStateListener(
   n_tilde.param(tf_prefix_key, tf_prefix_, std::string(""));
   publish_interval_ = ros::Duration(1.0/max(publish_freq, 1.0));
   */
-
+  tf_prefix_="";
+  node->declare_parameter("tf_prefix");
+  node->get_parameter("tf_prefix",tf_prefix_);
   use_tf_static_ = true;
   ignore_timestamp_ = false;
-  tf_prefix_ = "";
   // auto publish_freq = 50.0;
   // publish_interval_ = std::chrono::seconds(1.0/std::max(publish_freq, 1.0));
   publish_interval_ = 1s;


### PR DESCRIPTION
As discussed in [issue 125](https://github.com/ros/robot_state_publisher/issues/125), the tf_prefix parameter for robot_state_publisher was a useful and reasonable parameter for the node.  The functionality still exists in the current ROS2 head except for the commented out parameter reading, which needed to be migrated to use ROS2 parameter syntax.  This PR adds the parameter back into ROS2, so that multiple robot_state_publishers can be loaded with the same URDF and push out info on the main /tf topic, but where each parent/child in "namespace" by the tf_prefix.

There is some confusion about tf_prefix, since tf_prefix() was removed from tf2, but this tf_prefix is largely orthogonal to that.  If desired, the parameter could be called tf_namespace, though pre-appending the "namespace" is still called tf_prefix in Rviz2 RobotModel plugin (and still works there the same as in RViz1).