### PR TITLE
Replace deprecated launch_ros usage

### DIFF
--- a/launch/rsp-launch-urdf-file1.py
+++ b/launch/rsp-launch-urdf-file1.py
@@ -50,7 +50,7 @@ def generate_launch_description():
 
     params = {'robot_description': robot_desc}
     rsp = launch_ros.actions.Node(package='robot_state_publisher',
-                                  node_executable='robot_state_publisher',
+                                  executable='robot_state_publisher',
                                   output='both',
                                   parameters=[params])
 

--- a/launch/rsp-launch-urdf-file2.py
+++ b/launch/rsp-launch-urdf-file2.py
@@ -50,7 +50,7 @@ def generate_launch_description():
 
     params = {'robot_description': robot_desc}
     rsp = launch_ros.actions.Node(package='robot_state_publisher',
-                                  node_executable='robot_state_publisher',
+                                  executable='robot_state_publisher',
                                   output='both',
                                   parameters=[params])
 

--- a/launch/rsp-launch-urdf-inline.py
+++ b/launch/rsp-launch-urdf-inline.py
@@ -53,7 +53,7 @@ def generate_launch_description():
 
     params = {'robot_description': robot_desc}
     rsp = launch_ros.actions.Node(package='robot_state_publisher',
-                                  node_executable='robot_state_publisher',
+                                  executable='robot_state_publisher',
                                   output='both',
                                   parameters=[params])
 

--- a/launch/rsp-launch-xacro-api.py
+++ b/launch/rsp-launch-xacro-api.py
@@ -50,7 +50,7 @@ def generate_launch_description():
     robot_desc = doc.toprettyxml(indent='  ')
     params = {'robot_description': robot_desc}
     rsp = launch_ros.actions.Node(package='robot_state_publisher',
-                                  node_executable='robot_state_publisher',
+                                  executable='robot_state_publisher',
                                   output='both',
                                   parameters=[params])
 

--- a/launch/rsp-launch-xacro-command-subst.py
+++ b/launch/rsp-launch-xacro-command-subst.py
@@ -48,7 +48,7 @@ def generate_launch_description():
     robot_desc = launch.substitutions.Command('xacro %s' % xacro_file)
     params = {'robot_description': robot_desc}
     rsp = launch_ros.actions.Node(package='robot_state_publisher',
-                                  node_executable='robot_state_publisher',
+                                  executable='robot_state_publisher',
                                   output='both',
                                   parameters=[params])
 

--- a/launch/rsp-launch-xacro-popen.py
+++ b/launch/rsp-launch-xacro-popen.py
@@ -49,7 +49,7 @@ def generate_launch_description():
     robot_desc, stderr = p.communicate()
     params = {'robot_description': robot_desc.decode('utf-8')}
     rsp = launch_ros.actions.Node(package='robot_state_publisher',
-                                  node_executable='robot_state_publisher',
+                                  executable='robot_state_publisher',
                                   output='both',
                                   parameters=[params])
 

--- a/test/two_links_fixed_joint-launch.py
+++ b/test/two_links_fixed_joint-launch.py
@@ -59,7 +59,7 @@ def generate_test_description():
     params = {'robot_description': robot_desc}
     node_robot_state_publisher = Node(
         package='robot_state_publisher',
-        node_executable='robot_state_publisher',
+        executable='robot_state_publisher',
         output='screen',
         parameters=[params]
     )

--- a/test/two_links_moving_joint-launch.py
+++ b/test/two_links_moving_joint-launch.py
@@ -59,7 +59,7 @@ def generate_test_description():
     params = {'robot_description': robot_desc}
     node_robot_state_publisher = Node(
         package='robot_state_publisher',
-        node_executable='robot_state_publisher',
+        executable='robot_state_publisher',
         output='screen',
         parameters=[params]
     )


### PR DESCRIPTION
The Node parameter 'node_executable' has been deprecated and
replaced with 'executable'.

Depends on https://github.com/ros2/launch_ros/pull/140