### PR TITLE
Restore tf_prefix support

### DIFF
--- a/include/robot_state_publisher/joint_state_listener.h
+++ b/include/robot_state_publisher/joint_state_listener.h
@@ -75,6 +75,7 @@ protected:
   virtual void callbackJointState(const JointStateConstPtr& state);
   virtual void callbackFixedJoint(const ros::TimerEvent& e);
 
+  std::string tf_prefix_;
   ros::Duration publish_interval_;
   std::shared_ptr<RobotStatePublisher> state_publisher_;
   ros::Subscriber joint_state_sub_;

--- a/include/robot_state_publisher/robot_state_publisher.h
+++ b/include/robot_state_publisher/robot_state_publisher.h
@@ -80,8 +80,8 @@ public:
    * \param joint_positions A map of joint names and joint positions.
    * \param time The time at which the joint positions were recorded
    */
-  virtual void publishTransforms(const std::map<std::string, double>& joint_positions, const ros::Time& time);
-  virtual void publishFixedTransforms(bool use_tf_static = false);
+  virtual void publishTransforms(const std::map<std::string, double>& joint_positions, const ros::Time& time, const std::string& tf_prefix);
+  virtual void publishFixedTransforms(const std::string& tf_prefix, bool use_tf_static = false);
 
 protected:
   virtual void addChildren(const KDL::SegmentMap::const_iterator segment);

--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -71,6 +71,9 @@ JointStateListener::JointStateListener(const std::shared_ptr<RobotStatePublisher
   // ignore_timestamp_ == true, joins_states messages are accepted, no matter their timestamp
   n_tilde.param("ignore_timestamp", ignore_timestamp_, false);
   // get the tf_prefix parameter from the closest namespace
+  std::string tf_prefix_key;
+  n_tilde.searchParam("tf_prefix", tf_prefix_key);
+  n_tilde.param(tf_prefix_key, tf_prefix_, std::string(""));
   publish_interval_ = ros::Duration(1.0/std::max(publish_freq, 1.0));
 
   // Setting tcpNoNelay tells the subscriber to ask publishers that connect
@@ -94,7 +97,7 @@ JointStateListener::~JointStateListener()
 void JointStateListener::callbackFixedJoint(const ros::TimerEvent& e)
 {
   (void)e;
-  state_publisher_->publishFixedTransforms(use_tf_static_);
+  state_publisher_->publishFixedTransforms(tf_prefix_, use_tf_static_);
 }
 
 void JointStateListener::callbackJointState(const JointStateConstPtr& state)
@@ -150,7 +153,7 @@ void JointStateListener::callbackJointState(const JointStateConstPtr& state)
       }
     }
 
-    state_publisher_->publishTransforms(joint_positions, state->header.stamp);
+    state_publisher_->publishTransforms(joint_positions, state->header.stamp, tf_prefix_);
 
     // store publish time in joint map
     for (size_t i = 0; i<state->name.size(); ++i) {

--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -72,7 +72,7 @@ JointStateListener::JointStateListener(const std::shared_ptr<RobotStatePublisher
   n_tilde.param("ignore_timestamp", ignore_timestamp_, false);
   // get the tf_prefix parameter from the closest namespace
   std::string tf_prefix_key;
-  n_tilde.searchParam("tf_prefix", tf_prefix_key);
+  n_tilde.searchParam("prefix_tf_with", tf_prefix_key);
   n_tilde.param(tf_prefix_key, tf_prefix_, std::string(""));
   publish_interval_ = ros::Duration(1.0/std::max(publish_freq, 1.0));
 

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -97,9 +97,8 @@ std::string resolve(const std::string &prefix, const std::string &frame)
     return stripSlash(frame);
 
   std::string composite;
-  composite.reserve(prefix.length() + frame.length() + 1);
+  composite.reserve(prefix.length() + frame.length());
   composite.append(stripSlash(prefix));
-  composite.append("/");
   composite.append(stripSlash(frame));
   return composite;
 }


### PR DESCRIPTION
As discussed in #125, the `tf_prefix` parameter for `robot_state_publisher` was a useful and reasonable parameter. With the full migration from `tf` to `tf2` in #82, the tf_prefix functionality was removed as well, thus breaking behavior for many users, e.g. https://github.com/ros-visualization/rviz/issues/1507 and #125. 
A similar PR for ROS2 was filed in #127.
The TF and RobotModel displays in rviz still support the `tf_prefix` parameter as well (after intervention from some users).

This PR partially reverts #82.