### PR TITLE
[Foxy Backport] fix types in range loops to avoid copy due to different type (#143)

### DIFF
--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -173,14 +173,14 @@ void RobotStatePublisher::setupURDF(const std::string & urdf_xml)
 
   // Initialize the mimic map
   mimic_.clear();
-  for (const std::pair<std::string, urdf::JointSharedPtr> & i : model_->joints_) {
+  for (const std::pair<const std::string, urdf::JointSharedPtr> & i : model_->joints_) {
     if (i.second->mimic) {
       mimic_.insert(std::make_pair(i.first, i.second->mimic));
     }
   }
 
   KDL::SegmentMap segments_map = tree.getSegments();
-  for (const std::pair<std::string, KDL::TreeElement> & segment : segments_map) {
+  for (const std::pair<const std::string, KDL::TreeElement> & segment : segments_map) {
     RCLCPP_INFO(get_logger(), "got segment %s", segment.first.c_str());
   }
 
@@ -237,7 +237,7 @@ void RobotStatePublisher::publishTransforms(
   std::vector<geometry_msgs::msg::TransformStamped> tf_transforms;
 
   // loop over all joints
-  for (const std::pair<std::string, double> & jnt : joint_positions) {
+  for (const std::pair<const std::string, double> & jnt : joint_positions) {
     std::map<std::string, SegmentPair>::iterator seg = segments_.find(jnt.first);
     if (seg != segments_.end()) {
       geometry_msgs::msg::TransformStamped tf_transform =
@@ -258,7 +258,7 @@ void RobotStatePublisher::publishFixedTransforms()
   std::vector<geometry_msgs::msg::TransformStamped> tf_transforms;
 
   // loop over all fixed segments
-  for (const std::pair<std::string, SegmentPair> & seg : segments_fixed_) {
+  for (const std::pair<const std::string, SegmentPair> & seg : segments_fixed_) {
     geometry_msgs::msg::TransformStamped tf_transform = kdlToTransform(seg.second.segment.pose(0));
     rclcpp::Time now = this->now();
     if (!use_tf_static_) {
@@ -319,7 +319,7 @@ void RobotStatePublisher::callbackJointState(const sensor_msgs::msg::JointState:
       joint_positions.insert(std::make_pair(state->name[i], state->position[i]));
     }
 
-    for (const std::pair<std::string, urdf::JointMimicSharedPtr> & i : mimic_) {
+    for (const std::pair<const std::string, urdf::JointMimicSharedPtr> & i : mimic_) {
       if (joint_positions.find(i.second->joint_name) != joint_positions.end()) {
         double pos = joint_positions[i.second->joint_name] * i.second->multiplier +
           i.second->offset;


### PR DESCRIPTION
backport of #143 