### PR TITLE
Restore tf_prefix support for ROS2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,6 @@ if(BUILD_TESTING)
   add_executable(test_two_links_fixed_joint test/test_two_links_fixed_joint.cpp)
   ament_target_dependencies(test_two_links_fixed_joint
     rclcpp
-    sensor_msgs
     tf2_ros
   )
   target_link_libraries(test_two_links_fixed_joint ${GTEST_LIBRARIES})
@@ -83,7 +82,6 @@ if(BUILD_TESTING)
   add_executable(test_two_links_fixed_joint_prefix test/test_two_links_fixed_joint_prefix.cpp)
   ament_target_dependencies(test_two_links_fixed_joint_prefix
     rclcpp
-    sensor_msgs
     tf2_ros
   )
   target_link_libraries(test_two_links_fixed_joint_prefix ${GTEST_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,16 @@ if(BUILD_TESTING)
   add_launch_test(test/two_links_fixed_joint-launch.py
     ARGS "test_exe:=$<TARGET_FILE:test_two_links_fixed_joint>")
 
+  add_executable(test_two_links_fixed_joint_prefix test/test_two_links_fixed_joint_prefix.cpp)
+  ament_target_dependencies(test_two_links_fixed_joint_prefix
+    rclcpp
+    sensor_msgs
+    tf2_ros
+  )
+  target_link_libraries(test_two_links_fixed_joint_prefix ${GTEST_LIBRARIES})
+  add_launch_test(test/two_links_fixed_joint_prefix-launch.py
+    ARGS "test_exe:=$<TARGET_FILE:test_two_links_fixed_joint_prefix>")
+
   add_executable(test_two_links_moving_joint test/test_two_links_moving_joint.cpp)
   ament_target_dependencies(test_two_links_moving_joint
     rclcpp

--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ Parameters
 * `publish_frequency` (double) - The frequency at which fixed transforms will be republished to the network.  Defaults to 50.0.
 * `use_tf_static` (bool) - Whether to publish fixed joints on the static broadcaster (`/tf_static` topic) or on the dynamic one (`/tf` topic).  Defaults to true, so it publishes on the `/tf_static` topic.
 * `ignore_timestamp` (bool) - Whether to accept all joint states no matter what the timestamp (true), or to only publish joint state updates if they are newer than the last publish_frequency (false).  Defaults to false.
+* `frame_prefix` (string) - An arbitrary prefix to add to the published tf2 frames.  Defaults to the empty string.

--- a/include/robot_state_publisher/robot_state_publisher.hpp
+++ b/include/robot_state_publisher/robot_state_publisher.hpp
@@ -101,7 +101,7 @@ protected:
   MimicMap mimic_;
   bool use_tf_static_;
   bool ignore_timestamp_;
-  std::string tf_prefix_;
+  std::string frame_prefix_;
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_cb_;
 };
 

--- a/include/robot_state_publisher/robot_state_publisher.hpp
+++ b/include/robot_state_publisher/robot_state_publisher.hpp
@@ -101,6 +101,7 @@ protected:
   MimicMap mimic_;
   bool use_tf_static_;
   bool ignore_timestamp_;
+  std::string tf_prefix_;
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_cb_;
 };
 

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -125,6 +125,12 @@ RobotStatePublisher::RobotStatePublisher(const rclcpp::NodeOptions & options)
     RCLCPP_WARN(get_logger(), "use_tf_static is deprecated and will be removed in the future");
   }
 
+  // set tf_prefix and add trailing slash if its set
+  tf_prefix_ = this->declare_parameter("tf_prefix", "");
+  if (tf_prefix_.size()) {
+    tf_prefix_ = tf_prefix_ + "/";
+  }
+
   // ignore_timestamp_ == true, joint_state messages are accepted, no matter their timestamp
   ignore_timestamp_ = this->declare_parameter("ignore_timestamp", false);
 
@@ -241,8 +247,8 @@ void RobotStatePublisher::publishTransforms(
       geometry_msgs::msg::TransformStamped tf_transform =
         kdlToTransform(seg->second.segment.pose(jnt.second));
       tf_transform.header.stamp = time;
-      tf_transform.header.frame_id = seg->second.root;
-      tf_transform.child_frame_id = seg->second.tip;
+      tf_transform.header.frame_id = tf_prefix_ + seg->second.root;
+      tf_transform.child_frame_id = tf_prefix_ + seg->second.tip;
       tf_transforms.push_back(tf_transform);
     }
   }
@@ -264,8 +270,8 @@ void RobotStatePublisher::publishFixedTransforms()
     }
     tf_transform.header.stamp = now;
 
-    tf_transform.header.frame_id = seg.second.root;
-    tf_transform.child_frame_id = seg.second.tip;
+    tf_transform.header.frame_id = tf_prefix_ + seg.second.root;
+    tf_transform.child_frame_id = tf_prefix_ + seg.second.tip;
     tf_transforms.push_back(tf_transform);
   }
   if (use_tf_static_) {
@@ -373,6 +379,16 @@ rcl_interfaces::msg::SetParametersResult RobotStatePublisher::parameterUpdate(
         break;
       }
       use_tf_static_ = parameter.as_bool();
+    } else if (parameter.get_name() == "tf_prefix") {
+      if (parameter.get_type() != rclcpp::ParameterType::PARAMETER_STRING) {
+        result.successful = false;
+        result.reason = "tf_prefix must be a string";
+        break;
+      }
+      tf_prefix_ = parameter.as_string() + "/";
+      if (tf_prefix_.size()) {
+        tf_prefix_ = tf_prefix_ + "/";
+      }
     } else if (parameter.get_name() == "ignore_timestamp") {
       if (parameter.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
         result.successful = false;

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -36,6 +36,7 @@
 #include <kdl_parser/kdl_parser.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
 #include <std_msgs/msg/string.hpp>
 #include <urdf/model.h>
 

--- a/test/test_two_links_fixed_joint.cpp
+++ b/test/test_two_links_fixed_joint.cpp
@@ -29,7 +29,6 @@
 #include <gtest/gtest.h>
 
 #include <rclcpp/rclcpp.hpp>
-#include <sensor_msgs/msg/joint_state.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/test/test_two_links_fixed_joint_prefix.cpp
+++ b/test/test_two_links_fixed_joint_prefix.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2008, Willow Garage, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+
+#include <chrono>
+#include <cmath>
+#include <memory>
+#include <thread>
+
+#define EPS 0.01
+
+TEST(test_publisher, test_two_links_fixed_joint_prefix)
+{
+  auto node = rclcpp::Node::make_shared("rsp_test_two_links_fixed_joint_prefix");
+
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  tf2_ros::Buffer buffer(clock);
+  tf2_ros::TransformListener tfl(buffer, node, true);
+
+  for (unsigned int i = 0;
+    i < 100 && !buffer.canTransform("my_prefix/link1", "my_prefix/link2", rclcpp::Time()); i++)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  ASSERT_TRUE(buffer.canTransform("my_prefix/link1", "my_prefix/link2", rclcpp::Time()));
+  ASSERT_FALSE(buffer.canTransform("base_link", "wim_link", rclcpp::Time()));
+
+  geometry_msgs::msg::TransformStamped t = buffer.lookupTransform(
+    "my_prefix/link1", "my_prefix/link2", rclcpp::Time());
+  EXPECT_NEAR(t.transform.translation.x, 5.0, EPS);
+  EXPECT_NEAR(t.transform.translation.y, 0.0, EPS);
+  EXPECT_NEAR(t.transform.translation.z, 0.0, EPS);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  int res = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return res;
+}

--- a/test/test_two_links_fixed_joint_prefix.cpp
+++ b/test/test_two_links_fixed_joint_prefix.cpp
@@ -29,7 +29,6 @@
 #include <gtest/gtest.h>
 
 #include <rclcpp/rclcpp.hpp>
-#include <sensor_msgs/msg/joint_state.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/test/two_links_fixed_joint_prefix-launch.py
+++ b/test/two_links_fixed_joint_prefix-launch.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2020 Open Source Robotics Foundation, Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the copyright holder nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import unittest
+
+import launch
+from launch import LaunchDescription
+from launch_ros.actions import Node
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+
+
+def generate_test_description():
+    test_exe_arg = launch.actions.DeclareLaunchArgument(
+        'test_exe',
+        description='Path to executable test',
+    )
+
+    process_under_test = launch.actions.ExecuteProcess(
+        cmd=[launch.substitutions.LaunchConfiguration('test_exe')],
+        output='screen',
+    )
+
+    urdf_file = os.path.join(os.path.dirname(__file__), 'two_links_fixed_joint.urdf')
+    with open(urdf_file, 'r') as infp:
+        robot_desc = infp.read()
+
+    params = {
+        'robot_description': robot_desc,
+        'frame_prefix': 'my_prefix/',
+    }
+    node_robot_state_publisher = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        output='screen',
+        parameters=[params]
+    )
+
+    return LaunchDescription([
+        node_robot_state_publisher,
+        test_exe_arg,
+        process_under_test,
+        launch_testing.util.KeepAliveProc(),
+        launch_testing.actions.ReadyToTest(),
+    ]), locals()
+
+
+class TestFixedJoint(unittest.TestCase):
+
+    def test_termination(self, process_under_test, proc_info):
+        proc_info.assertWaitForShutdown(process=process_under_test, timeout=(10))
+
+
+@launch_testing.post_shutdown_test()
+class FixedJointTestAfterShutdown(unittest.TestCase):
+
+    def test_exit_code(self, process_under_test, proc_info):
+        # Check that all processes in the launch (in this case, there's just one) exit
+        # with code 0
+        launch_testing.asserts.assertExitCodes(
+            proc_info,
+            [launch_testing.asserts.EXIT_OK],
+            process_under_test
+        )


### PR DESCRIPTION
Relevant issue: https://github.com/ros/robot_state_publisher/issues/147
Relevant PRs: Noetic support: https://github.com/ros/robot_state_publisher/pull/139 Closed ROS2 PR: https://github.com/ros/robot_state_publisher/pull/127

This is a quick and dirty implementation of tf_prefix for foxy. Once the string formatting issues are resolved in https://github.com/ros/robot_state_publisher/pull/139, I recommend adding them here. If this is too duplicative feel free to close this.