### PR TITLE
Stop rejecting unknown parameters.

### DIFF
--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -402,10 +402,6 @@ rcl_interfaces::msg::SetParametersResult RobotStatePublisher::parameterUpdate(
         timer_ = this->create_wall_timer(
           publish_interval_ms_, std::bind(&RobotStatePublisher::publishFixedTransforms, this));
       }
-    } else {
-      result.successful = false;
-      result.reason = "Invalid parameter";
-      break;
     }
   }
 


### PR DESCRIPTION
This was never correct, but in Galactic this is fatal in several
ways.  Just remove it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>