### PR TITLE
Remove dependency on urdfdom_headers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,13 +21,13 @@ find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(urdf REQUIRED)
-find_package(urdfdom_headers REQUIRED)
-
-include_directories(include)
 
 add_library(
   ${PROJECT_NAME}_node SHARED
   src/robot_state_publisher.cpp)
+target_include_directories(${PROJECT_NAME}_node PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>")
 ament_target_dependencies(${PROJECT_NAME}_node
   builtin_interfaces
   geometry_msgs

--- a/package.xml
+++ b/package.xml
@@ -28,7 +28,6 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>tf2_ros</build_depend>
   <build_depend>urdf</build_depend>
-  <build_depend>urdfdom_headers</build_depend>
 
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
@@ -40,7 +39,6 @@
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>urdf</exec_depend>
-  <exec_depend>urdfdom_headers</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
It has no direct dependency, so no need to declare it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>