### PR TITLE
Fix deprecated subscriber callback warnings

### DIFF
--- a/include/robot_state_publisher/robot_state_publisher.hpp
+++ b/include/robot_state_publisher/robot_state_publisher.hpp
@@ -114,7 +114,7 @@ protected:
    *
    * \param[in] state The JointState message that was delivered.
    */
-  void callbackJointState(const sensor_msgs::msg::JointState::SharedPtr state);
+  void callbackJointState(const sensor_msgs::msg::JointState::ConstSharedPtr state);
 
   /// The callback that is called when parameters on the node are changed.
   /**

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -264,7 +264,8 @@ void RobotStatePublisher::publishFixedTransforms()
   static_tf_broadcaster_->sendTransform(tf_transforms);
 }
 
-void RobotStatePublisher::callbackJointState(const sensor_msgs::msg::JointState::SharedPtr state)
+void RobotStatePublisher::callbackJointState(
+  const sensor_msgs::msg::JointState::ConstSharedPtr state)
 {
   if (state->name.size() != state->position.size()) {
     if (state->position.empty()) {


### PR DESCRIPTION
ros2/rclcpp#1713 deprecates the `void shared_ptr<T>` subscription callback signatures, so this PR migrates away from said signatures.

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>