### PR TITLE
Change how parameter updates are handled.

### DIFF
--- a/include/robot_state_publisher/robot_state_publisher.hpp
+++ b/include/robot_state_publisher/robot_state_publisher.hpp
@@ -78,7 +78,7 @@ public:
   explicit RobotStatePublisher(const rclcpp::NodeOptions & options);
 
 protected:
-  std::pair<std::shared_ptr<urdf::Model>, KDL::Tree> parseURDF(const std::string & urdf_xml);
+  KDL::Tree parseURDF(const std::string & urdf_xml, urdf::Model & model);
 
   /// Setup the URDF for use.
   /**
@@ -97,7 +97,7 @@ protected:
    * \param[in] segment An iterator to the SegmentMap to add to the internal segment list.
    */
   void addChildren(
-    std::shared_ptr<urdf::Model> model,
+    const urdf::Model & model,
     const KDL::SegmentMap::const_iterator segment);
 
   /// Publish transforms to /tf2.

--- a/include/robot_state_publisher/robot_state_publisher.hpp
+++ b/include/robot_state_publisher/robot_state_publisher.hpp
@@ -33,6 +33,7 @@
 
 #include <builtin_interfaces/msg/time.hpp>
 #include <kdl/tree.hpp>
+#include <rcl_interfaces/msg/parameter_event.hpp>
 #include <rcl_interfaces/msg/set_parameters_result.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
@@ -45,6 +46,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 using MimicMap = std::map<std::string, urdf::JointMimicSharedPtr>;
@@ -76,6 +78,8 @@ public:
   explicit RobotStatePublisher(const rclcpp::NodeOptions & options);
 
 protected:
+  std::pair<std::shared_ptr<urdf::Model>, KDL::Tree> parseURDF(const std::string & urdf_xml);
+
   /// Setup the URDF for use.
   /**
    * This method first parses the URDF into an internal representation.
@@ -92,7 +96,9 @@ protected:
    *
    * \param[in] segment An iterator to the SegmentMap to add to the internal segment list.
    */
-  void addChildren(const KDL::SegmentMap::const_iterator segment);
+  void addChildren(
+    std::shared_ptr<urdf::Model> model,
+    const KDL::SegmentMap::const_iterator segment);
 
   /// Publish transforms to /tf2.
   /**
@@ -117,23 +123,29 @@ protected:
    */
   void callbackJointState(const sensor_msgs::msg::JointState::ConstSharedPtr state);
 
+  /// The callback that is called to check that new parameters are valid.
+  /**
+   * This allows the class to reject parameter updates that are invalid.
+   *
+   * \param[in] parameters The vector of parameters that are going to change.
+   * \return SetParametersResult with successful set to true on success, false otherwise.
+   */
+  rcl_interfaces::msg::SetParametersResult parameterUpdate(
+    const std::vector<rclcpp::Parameter> & parameters);
+
   /// The callback that is called when parameters on the node are changed.
   /**
    * This allows the class to dynamically react to changes in parameters.
    *
-   * \param[in] parameters The list of parameters that are going to change.
+   * \param[in] event The parameter change event that occurred.
    */
-  rcl_interfaces::msg::SetParametersResult parameterUpdate(
-    const std::vector<rclcpp::Parameter> & parameters);
+  void onParameterEvent(std::shared_ptr<const rcl_interfaces::msg::ParameterEvent> event);
 
   /// A map of dynamic segment names to SegmentPair structures
   std::map<std::string, SegmentPair> segments_;
 
   /// A map of fixed segment names to SegmentPair structures
   std::map<std::string, SegmentPair> segments_fixed_;
-
-  /// A pointer to the parsed URDF model
-  std::unique_ptr<urdf::Model> model_;
 
   /// A pointer to the tf2 TransformBroadcaster
   std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
@@ -143,9 +155,6 @@ protected:
 
   /// A pointer to the ROS 2 publisher for the robot_description
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr description_pub_;
-
-  /// The minimum publish interval between dynamic frame pairs
-  std::chrono::milliseconds publish_interval_ms_;
 
   /// A pointer to the ROS 2 subscription for the joint states
   rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_state_sub_;
@@ -167,6 +176,10 @@ protected:
 
   /// The parameter event callback that will be called when a parameter is changed
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_cb_;
+
+  /// The parameter event callback that will be called when a parameter is changed
+  std::shared_ptr<rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent,
+    std::allocator<void>>> parameter_subscription_;
 };
 
 }  // namespace robot_state_publisher

--- a/include/robot_state_publisher/robot_state_publisher.hpp
+++ b/include/robot_state_publisher/robot_state_publisher.hpp
@@ -42,11 +42,9 @@
 #include <tf2_ros/transform_broadcaster.h>
 #include <urdf/model.h>
 
-#include <chrono>
 #include <map>
 #include <memory>
 #include <string>
-#include <utility>
 #include <vector>
 
 using MimicMap = std::map<std::string, urdf::JointMimicSharedPtr>;

--- a/include/robot_state_publisher/robot_state_publisher.hpp
+++ b/include/robot_state_publisher/robot_state_publisher.hpp
@@ -168,12 +168,6 @@ protected:
   /// A map of the mimic joints that should be published
   MimicMap mimic_;
 
-  /// Whether to ignore timestamps while publishing
-  bool ignore_timestamp_;
-
-  /// An arbitrary prefix to add to tf2 frames before publishing
-  std::string frame_prefix_;
-
   /// The parameter event callback that will be called when a parameter is changed
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_cb_;
 

--- a/package.xml
+++ b/package.xml
@@ -16,8 +16,8 @@
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>kdl_parser</build_depend>
-  <build_depend>rcl_interfaces</build_depend>
   <build_depend>orocos_kdl</build_depend>
+  <build_depend>rcl_interfaces</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rclcpp_components</build_depend>
   <build_depend>sensor_msgs</build_depend>

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -44,7 +44,6 @@
 #include <urdf/model.h>
 
 #include <chrono>
-#include <cstring>
 #include <fstream>
 #include <functional>
 #include <map>

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -34,7 +34,9 @@
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <kdl/tree.hpp>
 #include <kdl_parser/kdl_parser.hpp>
+#include <rcl_interfaces/msg/parameter_event.hpp>
 #include <rcl_interfaces/msg/set_parameters_result.hpp>
+#include <rclcpp/parameter_events_filter.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
@@ -118,8 +120,6 @@ RobotStatePublisher::RobotStatePublisher(const rclcpp::NodeOptions & options)
   if (publish_freq < 0.0 || publish_freq > 1000.0) {
     throw std::runtime_error("publish_frequency must be between 0 and 1000");
   }
-  publish_interval_ms_ =
-    std::chrono::milliseconds(static_cast<uint64_t>(1000.0 / publish_freq));
 
   // set frame_prefix
   frame_prefix_ = this->declare_parameter("frame_prefix", "");
@@ -154,26 +154,43 @@ RobotStatePublisher::RobotStatePublisher(const rclcpp::NodeOptions & options)
   // necessary setup, install the callback for updating parameters.
   param_cb_ = add_on_set_parameters_callback(
     std::bind(&RobotStatePublisher::parameterUpdate, this, std::placeholders::_1));
+
+  // Now that we have successfully declared the parameters and done all
+  // necessary setup, install the callback for updating parameters.
+  parameter_subscription_ = rclcpp::AsyncParametersClient::on_parameter_event(
+    this->get_node_topics_interface(),
+    std::bind(&RobotStatePublisher::onParameterEvent, this, std::placeholders::_1));
 }
 
-void RobotStatePublisher::setupURDF(const std::string & urdf_xml)
+std::pair<std::shared_ptr<urdf::Model>, KDL::Tree> RobotStatePublisher::parseURDF(
+  const std::string & urdf_xml)
 {
-  model_ = std::make_unique<urdf::Model>();
+  auto model = std::make_shared<urdf::Model>();
 
   // Initialize the model
-  if (!model_->initString(urdf_xml)) {
+  if (!model->initString(urdf_xml)) {
     throw std::runtime_error("Unable to initialize urdf::model from robot description");
   }
 
   // Initialize the KDL tree
   KDL::Tree tree;
-  if (!kdl_parser::treeFromUrdfModel(*model_, tree)) {
+  if (!kdl_parser::treeFromUrdfModel(*model, tree)) {
     throw std::runtime_error("Failed to extract kdl tree from robot description");
   }
 
+  return std::make_pair(model, tree);
+}
+
+void RobotStatePublisher::setupURDF(const std::string & urdf_xml)
+{
+  std::pair<std::shared_ptr<urdf::Model>, KDL::Tree> modeltree = parseURDF(urdf_xml);
+
+  std::shared_ptr<urdf::Model> model = std::get<0>(std::move(modeltree));
+  KDL::Tree tree = std::get<1>(modeltree);
+
   // Initialize the mimic map
   mimic_.clear();
-  for (const std::pair<const std::string, urdf::JointSharedPtr> & i : model_->joints_) {
+  for (const std::pair<const std::string, urdf::JointSharedPtr> & i : model->joints_) {
     if (i.second->mimic) {
       mimic_.insert(std::make_pair(i.first, i.second->mimic));
     }
@@ -187,7 +204,7 @@ void RobotStatePublisher::setupURDF(const std::string & urdf_xml)
   // walk the tree and add segments to segments_
   segments_.clear();
   segments_fixed_.clear();
-  addChildren(tree.getRootSegment());
+  addChildren(model, tree.getRootSegment());
 
   auto msg = std::make_unique<std_msgs::msg::String>();
   msg->data = urdf_xml;
@@ -197,7 +214,9 @@ void RobotStatePublisher::setupURDF(const std::string & urdf_xml)
 }
 
 // add children to correct maps
-void RobotStatePublisher::addChildren(const KDL::SegmentMap::const_iterator segment)
+void RobotStatePublisher::addChildren(
+  std::shared_ptr<urdf::Model> model,
+  const KDL::SegmentMap::const_iterator segment)
 {
   const std::string & root = GetTreeElementSegment(segment->second).getName();
 
@@ -206,8 +225,8 @@ void RobotStatePublisher::addChildren(const KDL::SegmentMap::const_iterator segm
     const KDL::Segment & child = GetTreeElementSegment(children[i]->second);
     SegmentPair s(GetTreeElementSegment(children[i]->second), root, child.getName());
     if (child.getJoint().getType() == KDL::Joint::None) {
-      if (model_->getJoint(child.getJoint().getName()) &&
-        model_->getJoint(child.getJoint().getName())->type == urdf::Joint::FLOATING)
+      if (model->getJoint(child.getJoint().getName()) &&
+        model->getJoint(child.getJoint().getName())->type == urdf::Joint::FLOATING)
       {
         RCLCPP_INFO(
           get_logger(), "Floating joint. Not adding segment from %s to %s.",
@@ -224,7 +243,7 @@ void RobotStatePublisher::addChildren(const KDL::SegmentMap::const_iterator segm
         get_logger(), "Adding moving segment from %s to %s", root.c_str(),
         child.getName().c_str());
     }
-    addChildren(children[i]);
+    addChildren(model, children[i]);
   }
 }
 
@@ -305,7 +324,10 @@ void RobotStatePublisher::callbackJointState(
 
   // check if we need to publish
   rclcpp::Time current_time(state->header.stamp);
-  rclcpp::Time max_publish_time = last_published + rclcpp::Duration(publish_interval_ms_);
+  double publish_freq = this->get_parameter("publish_frequency").get_value<double>();
+  std::chrono::milliseconds publish_interval_ms =
+    std::chrono::milliseconds(static_cast<uint64_t>(1000.0 / publish_freq));
+  rclcpp::Time max_publish_time = last_published + rclcpp::Duration(publish_interval_ms);
   if (ignore_timestamp_ || current_time.nanoseconds() >= max_publish_time.nanoseconds()) {
     // get joint positions from state message
     std::map<std::string, double> joint_positions;
@@ -338,65 +360,59 @@ rcl_interfaces::msg::SetParametersResult RobotStatePublisher::parameterUpdate(
 
   for (const rclcpp::Parameter & parameter : parameters) {
     if (parameter.get_name() == "robot_description") {
-      // First make sure that it is still a string
-      if (parameter.get_type() != rclcpp::ParameterType::PARAMETER_STRING) {
-        result.successful = false;
-        result.reason = "URDF must be a string";
-        break;
-      }
-
-      // Now get the parameter
       std::string new_urdf = parameter.as_string();
-      // And ensure that it isn't empty
+      // Ensure that it isn't empty
       if (new_urdf.empty()) {
         result.successful = false;
         result.reason = "Empty URDF is not allowed";
         break;
       }
 
+      // And that we can successfully parse it
       try {
-        setupURDF(new_urdf);
-        publishFixedTransforms();
+        parseURDF(new_urdf);
       } catch (const std::runtime_error & err) {
         RCLCPP_WARN(get_logger(), "%s", err.what());
         result.successful = false;
         result.reason = err.what();
         break;
       }
-    } else if (parameter.get_name() == "frame_prefix") {
-      if (parameter.get_type() != rclcpp::ParameterType::PARAMETER_STRING) {
-        result.successful = false;
-        result.reason = "frame_prefix must be a string";
-        break;
-      }
-      frame_prefix_ = parameter.as_string();
-    } else if (parameter.get_name() == "ignore_timestamp") {
-      if (parameter.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
-        result.successful = false;
-        result.reason = "ignore_timestamp must be a boolean";
-        break;
-      }
-      ignore_timestamp_ = parameter.as_bool();
     } else if (parameter.get_name() == "publish_frequency") {
-      if (parameter.get_type() != rclcpp::ParameterType::PARAMETER_DOUBLE) {
-        result.successful = false;
-        result.reason = "publish_frequency must be a double";
-        break;
-      }
-
       double publish_freq = parameter.as_double();
       if (publish_freq < 0.0 || publish_freq > 1000.0) {
         result.successful = false;
         result.reason = "publish_frequency must be between 0.0 and 1000.0";
         break;
       }
-      publish_interval_ms_ =
-        std::chrono::milliseconds(static_cast<uint64_t>(1000.0 / publish_freq));
     }
   }
 
   return result;
 }
+
+void RobotStatePublisher::onParameterEvent(
+  std::shared_ptr<const rcl_interfaces::msg::ParameterEvent> event)
+{
+  // Filter out events from other nodes
+  if (event->node != this->get_fully_qualified_name()) {
+    return;
+  }
+
+  // Filter for 'robot_description' being changed.
+  rclcpp::ParameterEventsFilter filter(event, {"robot_description"},
+    {rclcpp::ParameterEventsFilter::EventType::CHANGED});
+  for (auto & it : filter.get_events()) {
+    if (it.second->name == "robot_description") {
+      try {
+        setupURDF(it.second->value.string_value);
+        publishFixedTransforms();
+      } catch (const std::runtime_error & err) {
+        RCLCPP_WARN(get_logger(), "Failed to parse new URDF: %s", err.what());
+      }
+    }
+  }
+}
+
 }  // namespace robot_state_publisher
 
 RCLCPP_COMPONENTS_REGISTER_NODE(robot_state_publisher::RobotStatePublisher)


### PR DESCRIPTION
set_parameter callbacks should not have any side-effects.
This is most easy to understand if you think about the fact
that those callbacks can be chained; if callback A has a side-effect,
but then callback B rejects the entire set_parameter call, then
the nodes will be in an inconsistent state.

Instead, change it so that the set_parameter callback checks that
the incoming arguments are valid, and does nothing else.  We
setup a callback to listen to the /parameter_events topic;
at that point, we know that the update has been accepted by
all set_parameter callbacks, so it is safe for side-effects to happen.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>