### PR TITLE
Publish new fixed transforms when URDF is updated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,13 +68,12 @@ if(BUILD_TESTING)
   find_package(launch_testing_ament_cmake REQUIRED)
   ament_find_gtest()
 
-  include_directories(${GTEST_INCLUDE_DIRS})
-
   add_executable(test_two_links_fixed_joint test/test_two_links_fixed_joint.cpp)
   ament_target_dependencies(test_two_links_fixed_joint
     rclcpp
     tf2_ros
   )
+  target_include_directories(test_two_links_fixed_joint PRIVATE ${GTEST_INCLUDE_DIRS})
   target_link_libraries(test_two_links_fixed_joint ${GTEST_LIBRARIES})
   add_launch_test(test/two_links_fixed_joint-launch.py
     ARGS "test_exe:=$<TARGET_FILE:test_two_links_fixed_joint>")
@@ -84,6 +83,7 @@ if(BUILD_TESTING)
     rclcpp
     tf2_ros
   )
+  target_include_directories(test_two_links_fixed_joint PRIVATE ${GTEST_INCLUDE_DIRS})
   target_link_libraries(test_two_links_fixed_joint_prefix ${GTEST_LIBRARIES})
   add_launch_test(test/two_links_fixed_joint_prefix-launch.py
     ARGS "test_exe:=$<TARGET_FILE:test_two_links_fixed_joint_prefix>")
@@ -94,6 +94,7 @@ if(BUILD_TESTING)
     sensor_msgs
     tf2_ros
   )
+  target_include_directories(test_two_links_fixed_joint PRIVATE ${GTEST_INCLUDE_DIRS})
   target_link_libraries(test_two_links_moving_joint ${GTEST_LIBRARIES})
   add_launch_test(test/two_links_moving_joint-launch.py
     ARGS "test_exe:=$<TARGET_FILE:test_two_links_moving_joint>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,16 @@ if(BUILD_TESTING)
   target_link_libraries(test_two_links_moving_joint ${GTEST_LIBRARIES})
   add_launch_test(test/two_links_moving_joint-launch.py
     ARGS "test_exe:=$<TARGET_FILE:test_two_links_moving_joint>")
+
+  add_executable(test_two_links_change_fixed_joint test/test_two_links_change_fixed_joint.cpp)
+  ament_target_dependencies(test_two_links_change_fixed_joint
+    rclcpp
+    tf2_ros
+  )
+  target_include_directories(test_two_links_change_fixed_joint PRIVATE ${GTEST_INCLUDE_DIRS})
+  target_link_libraries(test_two_links_change_fixed_joint ${GTEST_LIBRARIES})
+  add_launch_test(test/two_links_change_fixed_joint-launch.py
+    ARGS "test_exe:=$<TARGET_FILE:test_two_links_change_fixed_joint>")
 endif()
 
 ament_export_dependencies(builtin_interfaces orocos_kdl rclcpp sensor_msgs std_msgs tf2_ros urdf)

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -355,6 +355,7 @@ rcl_interfaces::msg::SetParametersResult RobotStatePublisher::parameterUpdate(
 
       try {
         setupURDF(new_urdf);
+        publishFixedTransforms();
       } catch (const std::runtime_error & err) {
         RCLCPP_WARN(get_logger(), "%s", err.what());
         result.successful = false;

--- a/test/test_two_links_change_fixed_joint.cpp
+++ b/test/test_two_links_change_fixed_joint.cpp
@@ -1,0 +1,117 @@
+// Copyright (c) 2021, Open Source Robotics Foundation, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <rcl_interfaces/msg/set_parameters_result.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+
+#include <chrono>
+#include <cmath>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+static constexpr double EPS = 0.01;
+
+TEST(test_publisher, test_two_joints)
+{
+  auto node = rclcpp::Node::make_shared("rsp_test_two_links_change_fixed_joint");
+
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  tf2_ros::Buffer buffer(clock);
+  tf2_ros::TransformListener tfl(buffer, node, true);
+  unsigned int i;
+
+  for (i = 0; i < 100 && !buffer.canTransform("link1", "link2", rclcpp::Time()); ++i) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  ASSERT_TRUE(buffer.canTransform("link1", "link2", rclcpp::Time()));
+  ASSERT_FALSE(buffer.canTransform("base_link", "wim_link", rclcpp::Time()));
+
+  geometry_msgs::msg::TransformStamped t = buffer.lookupTransform("link1", "link2", rclcpp::Time());
+  EXPECT_NEAR(t.transform.translation.x, 5.0, EPS);
+  EXPECT_NEAR(t.transform.translation.y, 0.0, EPS);
+  EXPECT_NEAR(t.transform.translation.z, 0.0, EPS);
+
+  // OK, now publish a new URDF to the parameter and ensure that the link has been updated
+  auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(
+    node,
+    "robot_state_publisher");
+  for (i = 0; i < 100 && !parameters_client->wait_for_service(std::chrono::milliseconds(100));
+    ++i)
+  {
+    ASSERT_TRUE(rclcpp::ok());
+  }
+  ASSERT_LT(i, 100u);
+
+  std::string new_robot_description(
+    "<robot name=\"test_robot_fixed_joint\">"
+    "  <link name=\"link1\" />"
+    "  <link name=\"link2\" />"
+    "  <joint name=\"joint1\" type=\"fixed\">"
+    "    <parent link=\"link1\"/>"
+    "    <child link=\"link2\"/>"
+    "    <origin xyz=\"10 0 0\" rpy=\"0 0 1.57\" />"
+    "  </joint>"
+    "</robot>");
+  std::vector<rcl_interfaces::msg::SetParametersResult> set_parameters_result =
+    parameters_client->set_parameters(
+  {
+    rclcpp::Parameter("robot_description", new_robot_description)
+  }, std::chrono::milliseconds(500));
+  ASSERT_EQ(set_parameters_result.size(), 1u);
+  ASSERT_TRUE(set_parameters_result[0].successful);
+
+  for (i = 0; i < 100 && !buffer.canTransform("link1", "link2", rclcpp::Time()); ++i) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  ASSERT_TRUE(buffer.canTransform("link1", "link2", rclcpp::Time()));
+
+  t = buffer.lookupTransform("link1", "link2", rclcpp::Time());
+  EXPECT_NEAR(t.transform.translation.x, 10.0, EPS);
+  EXPECT_NEAR(t.transform.translation.y, 0.0, EPS);
+  EXPECT_NEAR(t.transform.translation.z, 0.0, EPS);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  int res = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return res;
+}

--- a/test/test_two_links_fixed_joint.cpp
+++ b/test/test_two_links_fixed_joint.cpp
@@ -37,7 +37,7 @@
 #include <memory>
 #include <thread>
 
-#define EPS 0.01
+static constexpr double EPS = 0.01;
 
 TEST(test_publisher, test_two_joints)
 {
@@ -47,7 +47,7 @@ TEST(test_publisher, test_two_joints)
   tf2_ros::Buffer buffer(clock);
   tf2_ros::TransformListener tfl(buffer, node, true);
 
-  for (unsigned int i = 0; i < 100 && !buffer.canTransform("link1", "link2", rclcpp::Time()); i++) {
+  for (unsigned int i = 0; i < 100 && !buffer.canTransform("link1", "link2", rclcpp::Time()); ++i) {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
 

--- a/test/test_two_links_moving_joint.cpp
+++ b/test/test_two_links_moving_joint.cpp
@@ -26,6 +26,12 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#ifdef _MSC_VER
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif
+#endif
+
 #include <gtest/gtest.h>
 
 #include <rclcpp/rclcpp.hpp>
@@ -38,11 +44,10 @@
 #include <memory>
 #include <thread>
 
-#define EPS 0.01
+static constexpr double EPS = 0.01;
 
 TEST(test_publisher, test_two_joints)
 {
-  const double pi = 3.14159265358979323846;
   auto node = rclcpp::Node::make_shared("rsp_test_two_links_moving_joint");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
@@ -53,10 +58,10 @@ TEST(test_publisher, test_two_joints)
     node->create_publisher<sensor_msgs::msg::JointState>("joint_states", 10);
   sensor_msgs::msg::JointState js_msg;
   js_msg.name.push_back("joint1");
-  js_msg.position.push_back(pi);
+  js_msg.position.push_back(M_PI);
   js_msg.header.stamp = node->now();
 
-  for (unsigned int i = 0; i < 100 && !buffer.canTransform("link1", "link2", rclcpp::Time()); i++) {
+  for (unsigned int i = 0; i < 100 && !buffer.canTransform("link1", "link2", rclcpp::Time()); ++i) {
     pub->publish(js_msg);
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }

--- a/test/two_links_change_fixed_joint-launch.py
+++ b/test/two_links_change_fixed_joint-launch.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2021 Open Source Robotics Foundation, Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the copyright holder nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import unittest
+
+import launch
+from launch import LaunchDescription
+from launch_ros.actions import Node
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+
+
+def generate_test_description():
+    test_exe_arg = launch.actions.DeclareLaunchArgument(
+        'test_exe',
+        description='Path to executable test',
+    )
+
+    process_under_test = launch.actions.ExecuteProcess(
+        cmd=[launch.substitutions.LaunchConfiguration('test_exe')],
+        output='screen',
+    )
+
+    urdf_file = os.path.join(os.path.dirname(__file__), 'two_links_fixed_joint.urdf')
+    with open(urdf_file, 'r') as infp:
+        robot_desc = infp.read()
+
+    params = {'robot_description': robot_desc}
+    node_robot_state_publisher = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        output='screen',
+        parameters=[params]
+    )
+
+    return LaunchDescription([
+        node_robot_state_publisher,
+        test_exe_arg,
+        process_under_test,
+        launch_testing.util.KeepAliveProc(),
+        launch_testing.actions.ReadyToTest(),
+    ]), locals()
+
+
+class TestChangeFixedJoint(unittest.TestCase):
+
+    def test_termination(self, process_under_test, proc_info):
+        proc_info.assertWaitForShutdown(process=process_under_test, timeout=(10))
+
+
+@launch_testing.post_shutdown_test()
+class ChangeFixedJointTestAfterShutdown(unittest.TestCase):
+
+    def test_exit_code(self, process_under_test, proc_info):
+        # Check that all processes in the launch (in this case, there's just one) exit
+        # with code 0
+        launch_testing.asserts.assertExitCodes(
+            proc_info,
+            [launch_testing.asserts.EXIT_OK],
+            process_under_test
+        )


### PR DESCRIPTION
A new URDF may come with a new set of fixed transforms, so if the URDF
is updated through the `robot_description` parameter, we also need to
publish its new transforms.

Fixes #181.