### PR TITLE
[Galactic backport]: Publish new fixed transforms when URDF is updated

### DIFF
--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -372,6 +372,7 @@ rcl_interfaces::msg::SetParametersResult RobotStatePublisher::parameterUpdate(
 
       try {
         setupURDF(new_urdf);
+        publishFixedTransforms();
       } catch (const std::runtime_error & err) {
         RCLCPP_WARN(get_logger(), "%s", err.what());
         result.successful = false;


### PR DESCRIPTION
A new URDF may come with a new set of fixed transforms, so if the URDF
is updated through the `robot_description` parameter, we also need to
publish its new transforms.

Fixes #181

Signed-off-by: Russell Joyce <russell@russellj.co.uk>

This backports just the fix in #182 to Galactic; the rest of the cleanup and the tests I didn't backport (since it didn't seem necessary here).

Fixes #188 