### PR TITLE
export dependencies, to use robot_state_publisher as a component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,13 +23,7 @@ find_package(std_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(urdf REQUIRED)
 
-add_library(
-  ${PROJECT_NAME}_node SHARED
-  src/robot_state_publisher.cpp)
-target_include_directories(${PROJECT_NAME}_node PUBLIC
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
-ament_target_dependencies(${PROJECT_NAME}_node
+set(THIS_PACKAGE_INCLUDE_DEPENDS
   builtin_interfaces
   geometry_msgs
   kdl_parser
@@ -40,9 +34,17 @@ ament_target_dependencies(${PROJECT_NAME}_node
   sensor_msgs
   std_msgs
   tf2_ros
-  urdf
-)
+  urdf)
+
+add_library(
+  ${PROJECT_NAME}_node SHARED
+  src/robot_state_publisher.cpp)
+target_include_directories(${PROJECT_NAME}_node PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+ament_target_dependencies(${PROJECT_NAME}_node ${THIS_PACKAGE_INCLUDE_DEPENDS})
 ament_export_targets(export_${PROJECT_NAME}_node)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 rclcpp_components_register_node(${PROJECT_NAME}_node
   PLUGIN "robot_state_publisher::RobotStatePublisher"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,6 @@ target_include_directories(${PROJECT_NAME}_node PUBLIC
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 ament_target_dependencies(${PROJECT_NAME}_node ${THIS_PACKAGE_INCLUDE_DEPENDS})
 ament_export_targets(export_${PROJECT_NAME}_node)
-ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 rclcpp_components_register_node(${PROJECT_NAME}_node
   PLUGIN "robot_state_publisher::RobotStatePublisher"
@@ -116,5 +115,5 @@ if(BUILD_TESTING)
     ARGS "test_exe:=$<TARGET_FILE:test_two_links_change_fixed_joint>")
 endif()
 
-ament_export_dependencies(builtin_interfaces orocos_kdl rclcpp sensor_msgs std_msgs tf2_ros urdf)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 ament_package()

--- a/package.xml
+++ b/package.xml
@@ -13,29 +13,17 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>builtin_interfaces</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>kdl_parser</build_depend>
-  <build_depend>orocos_kdl</build_depend>
-  <build_depend>rcl_interfaces</build_depend>
-  <build_depend>rclcpp</build_depend>
-  <build_depend>rclcpp_components</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>tf2_ros</build_depend>
-  <build_depend>urdf</build_depend>
-
-  <exec_depend>builtin_interfaces</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>kdl_parser</exec_depend>
-  <exec_depend>orocos_kdl</exec_depend>
-  <exec_depend>rcl_interfaces</exec_depend>
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>rclcpp_components</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>urdf</exec_depend>
+  <depend>builtin_interfaces</depend>
+  <depend>geometry_msgs</depend>
+  <depend>kdl_parser</depend>
+  <depend>orocos_kdl</depend>
+  <depend>rcl_interfaces</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2_ros</depend>
+  <depend>urdf</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Some dependencies are missing when using robot_state_publisher as a library. This PR:
* calls `ament_target_dependencies` on all dependencies
* replaces `build_depend` and `exec_depend` with the recommended `depend` tag in package.xml