### PR TITLE
fixes the following bug: /tf topics timestamps switch from simulated time to system time when bagfile playbag is stopped and use_sim_time is set

### DIFF
--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -345,7 +345,12 @@ void RobotStatePublisher::callbackJointState(
       }
     }
 
-    publishTransforms(joint_positions, state->header.stamp);
+    rclcpp::Parameter sim_p = this->get_parameter("use_sim_time");
+    if (sim_p.as_bool()) {
+      publishTransforms(joint_positions, now);
+    } else {
+      publishTransforms(joint_positions, state->header.stamp);
+    }
 
     // store publish time in joint map
     for (size_t i = 0; i < state->name.size(); i++) {


### PR DESCRIPTION
while the playback of a bagfile is stopped and use_sime_time is true the /tf topics timestamps switch from simulated time to system time causing eventually lots of error messages (rviz2 and so on)