### PR TITLE
Improve log messages

### DIFF
--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -192,7 +192,7 @@ void RobotStatePublisher::setupURDF(const std::string & urdf_xml)
 
   KDL::SegmentMap segments_map = tree.getSegments();
   for (const std::pair<const std::string, KDL::TreeElement> & segment : segments_map) {
-    RCLCPP_INFO(get_logger(), "got segment %s", segment.first.c_str());
+    RCLCPP_DEBUG(get_logger(), "Got segment %s", segment.first.c_str());
   }
 
   // walk the tree and add segments to segments_
@@ -205,6 +205,8 @@ void RobotStatePublisher::setupURDF(const std::string & urdf_xml)
 
   // Publish the robot description
   description_pub_->publish(std::move(msg));
+
+  RCLCPP_INFO(get_logger(), "Robot initialized");
 }
 
 // add children to correct maps
@@ -222,8 +224,8 @@ void RobotStatePublisher::addChildren(
       if (model.getJoint(child.getJoint().getName()) &&
         model.getJoint(child.getJoint().getName())->type == urdf::Joint::FLOATING)
       {
-        RCLCPP_INFO(
-          get_logger(), "Floating joint. Not adding segment from %s to %s.",
+        RCLCPP_DEBUG(
+          get_logger(), "Floating joint is not supported; skipping segment from %s to %s.",
           root.c_str(), child.getName().c_str());
       } else {
         segments_fixed_.insert(make_pair(child.getJoint().getName(), s));


### PR DESCRIPTION
The 'got segment' message generates a lot of output when you have a big robot. At the same time, it offers little to no value under normal circumstances. I change here the level to debug to avoid spamming.