### PR TITLE
upgrade to C++14 for compatibility with Eigen 3.40.90

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,22 +2,23 @@ cmake_minimum_required(VERSION 3.0.2)
 project(robot_state_publisher)
 
 include(CheckCXXCompilerFlag)
-unset(COMPILER_SUPPORTS_CXX11 CACHE)
+unset(COMPILER_SUPPORTS_CXX17 CACHE)
 if(MSVC)
   # https://docs.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version
   # MSVC will fail the following check since it does not have the c++11 switch
   # however, c++11 is always enabled (the newer /std:c++14 is enabled by default)
-  check_cxx_compiler_flag(/std:c++11 COMPILER_SUPPORTS_CXX11)
-  if(COMPILER_SUPPORTS_CXX11)
-    add_compile_options(/std:c++11)
+  # Oct. 06 2023: upgrade to c++17
+  check_cxx_compiler_flag(/std:c++17 COMPILER_SUPPORTS_CXX17)
+  if(COMPILER_SUPPORTS_CXX17)
+    add_compile_options(/std:c++17)
   endif()
 
   # MSVC does not support the Wextra flag
   add_compile_options(/Wall)
 else()
-  check_cxx_compiler_flag(-std=c++11 COMPILER_SUPPORTS_CXX11)
-  if(COMPILER_SUPPORTS_CXX11)
-    add_compile_options(-std=c++11)
+  check_cxx_compiler_flag(-std=c++17 COMPILER_SUPPORTS_CXX17)
+  if(COMPILER_SUPPORTS_CXX17)
+    add_compile_options(-std=c++17)
   endif()
   add_compile_options(-Wall -Wextra)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,24 +2,15 @@ cmake_minimum_required(VERSION 3.0.2)
 project(robot_state_publisher)
 
 include(CheckCXXCompilerFlag)
-unset(COMPILER_SUPPORTS_CXX17 CACHE)
-if(MSVC)
-  # https://docs.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version
-  # MSVC will fail the following check since it does not have the c++11 switch
-  # however, c++11 is always enabled (the newer /std:c++14 is enabled by default)
-  # Oct. 06 2023: upgrade to c++17
-  check_cxx_compiler_flag(/std:c++17 COMPILER_SUPPORTS_CXX17)
-  if(COMPILER_SUPPORTS_CXX17)
-    add_compile_options(/std:c++17)
-  endif()
+if (NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif ()
 
+if(MSVC)
   # MSVC does not support the Wextra flag
   add_compile_options(/Wall)
 else()
-  check_cxx_compiler_flag(-std=c++17 COMPILER_SUPPORTS_CXX17)
-  if(COMPILER_SUPPORTS_CXX17)
-    add_compile_options(-std=c++17)
-  endif()
   add_compile_options(-Wall -Wextra)
 endif()
 
@@ -44,6 +35,7 @@ link_directories(${orocos_kdl_LIBRARY_DIRS})
 add_library(${PROJECT_NAME}_solver
   src/robot_state_publisher.cpp
 )
+target_compile_features(${PROJECT_NAME}_solver PUBLIC cxx_std_14)
 target_link_libraries(${PROJECT_NAME}_solver ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES})
 
 add_library(joint_state_listener src/joint_state_listener.cpp)


### PR DESCRIPTION
With Eigen 3.40.90 installed from source, we need to change the C++ standard from 11 to 17. Otherwise, we get error: `#error This compiler appears to be too old to be supported by Eigen`.