### PR TITLE
Fix destructors should be public virtual

### DIFF
--- a/include/robot_state_publisher/joint_state_listener.h
+++ b/include/robot_state_publisher/joint_state_listener.h
@@ -69,7 +69,7 @@ public:
 
 
   /// Destructor
-  ~JointStateListener();
+  virtual ~JointStateListener();
 
 private:
   std::string getTFPrefix();

--- a/include/robot_state_publisher/robot_state_publisher.h
+++ b/include/robot_state_publisher/robot_state_publisher.h
@@ -74,7 +74,7 @@ public:
   RobotStatePublisher(const KDL::Tree& tree, const urdf::Model& model = urdf::Model());
 
   /// Destructor
-  ~RobotStatePublisher(){};
+  virtual ~RobotStatePublisher() = default;
 
   /** Publish transforms to tf
    * \param joint_positions A map of joint names and joint positions.


### PR DESCRIPTION
I encountered some compilation errors with clang. It complains that the destructor is not virtual. According to the cpp core guidelines a destructor should be either public and virtual or protected and non virtual. See also this link:
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c35-a-base-class-destructor-should-be-either-public-and-virtual-or-protected-and-non-virtual