### PR TITLE
Improvements

### DIFF
--- a/include/robot_state_publisher/robot_state_publisher.hpp
+++ b/include/robot_state_publisher/robot_state_publisher.hpp
@@ -47,10 +47,10 @@
 #include "tf2_ros/transform_broadcaster.hpp"
 #include "urdf/model.hpp"
 
-using MimicMap = std::map<std::string, urdf::JointMimicSharedPtr>;
-
 namespace robot_state_publisher
 {
+
+using MimicMap = std::map<std::string, urdf::JointMimicSharedPtr>;
 
 /// A class that represents a mapping between a KDL segment and its root and tip.
 class SegmentPair final
@@ -172,6 +172,15 @@ protected:
 
   /// A map of the mimic joints that should be published
   MimicMap mimic_;
+
+  /// Cached value of the publish_frequency parameter
+  double publish_frequency_;
+
+  /// Cached value of the ignore_timestamp parameter
+  bool ignore_timestamp_;
+
+  /// Cached value of the frame_prefix parameter
+  std::string frame_prefix_;
 
   /// The parameter event callback that will be called when a parameter is changed
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_cb_;

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -59,6 +59,11 @@ namespace robot_state_publisher
 namespace
 {
 
+inline bool check_valid_pub_freq(double val)
+{
+  return val > 0.0 && val <= 1000.0;
+}
+
 inline
 geometry_msgs::msg::TransformStamped kdlToTransform(const KDL::Frame & k)
 {
@@ -118,7 +123,7 @@ RobotStatePublisher::RobotStatePublisher(const rclcpp::NodeOptions & options)
 
   // set publish frequency
   publish_frequency_ = this->declare_parameter("publish_frequency", 20.0);
-  if (publish_frequency_ <= 0.0 || publish_frequency_ > 1000.0) {
+  if (!check_valid_pub_freq(publish_frequency_)) {
     throw std::runtime_error("publish_frequency must be between 0 (exclusive) and 1000");
   }
 
@@ -375,7 +380,7 @@ rcl_interfaces::msg::SetParametersResult RobotStatePublisher::parameterUpdate(
       }
     } else if (parameter.get_name() == "publish_frequency") {
       double publish_freq = parameter.as_double();
-      if (publish_freq <= 0.0 || publish_freq > 1000.0) {
+      if (!check_valid_pub_freq(publish_freq)) {
         result.successful = false;
         result.reason = "publish_frequency must be between 0.0 (exclusive) and 1000.0";
         break;

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -111,24 +111,22 @@ RobotStatePublisher::RobotStatePublisher(const rclcpp::NodeOptions & options)
     param_cb_ = add_on_set_parameters_callback(
       std::bind(&RobotStatePublisher::parameterUpdate, this, std::placeholders::_1));
 
-    // Now that we have successfully declared the parameters and done all
-    // necessary setup, install the callback for updating parameters.
     parameter_subscription_ = rclcpp::AsyncParametersClient::on_parameter_event(
       this->get_node_topics_interface(),
       std::bind(&RobotStatePublisher::onParameterEvent, this, std::placeholders::_1));
   }
 
   // set publish frequency
-  double publish_freq = this->declare_parameter("publish_frequency", 20.0);
-  if (publish_freq < 0.0 || publish_freq > 1000.0) {
-    throw std::runtime_error("publish_frequency must be between 0 and 1000");
+  publish_frequency_ = this->declare_parameter("publish_frequency", 20.0);
+  if (publish_frequency_ <= 0.0 || publish_frequency_ > 1000.0) {
+    throw std::runtime_error("publish_frequency must be between 0 (exclusive) and 1000");
   }
 
   // set frame_prefix
-  this->declare_parameter("frame_prefix", "");
+  frame_prefix_ = this->declare_parameter("frame_prefix", std::string(""));
 
   // ignore_timestamp_ == true, joint_state messages are accepted, no matter their timestamp
-  this->declare_parameter("ignore_timestamp", false);
+  ignore_timestamp_ = this->declare_parameter("ignore_timestamp", false);
 
   tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(*this);
   static_tf_broadcaster_ = std::make_unique<tf2_ros::StaticTransformBroadcaster>(*this);
@@ -182,7 +180,7 @@ void RobotStatePublisher::setupURDF(const std::string & urdf_xml)
     }
   }
 
-  KDL::SegmentMap segments_map = tree.getSegments();
+  const KDL::SegmentMap & segments_map = tree.getSegments();
   for (const std::pair<const std::string, KDL::TreeElement> & segment : segments_map) {
     RCLCPP_DEBUG(get_logger(), "Got segment %s", segment.first.c_str());
   }
@@ -211,9 +209,9 @@ void RobotStatePublisher::addChildren(
   const std::string & root = GetTreeElementSegment(segment->second).getName();
 
   std::vector<KDL::SegmentMap::const_iterator> children = GetTreeElementChildren(segment->second);
-  for (unsigned int i = 0; i < children.size(); i++) {
-    const KDL::Segment & child = GetTreeElementSegment(children[i]->second);
-    SegmentPair s(GetTreeElementSegment(children[i]->second), root, child.getName());
+  for (const KDL::SegmentMap::const_iterator & child_it : children) {
+    const KDL::Segment & child = GetTreeElementSegment(child_it->second);
+    SegmentPair s(GetTreeElementSegment(child_it->second), root, child.getName());
     if (child.getJoint().getType() == KDL::Joint::None) {
       if (model.getJoint(child.getJoint().getName()) &&
         model.getJoint(child.getJoint().getName())->type == urdf::Joint::FLOATING)
@@ -233,7 +231,7 @@ void RobotStatePublisher::addChildren(
         get_logger(), "Adding moving segment from %s to %s", root.c_str(),
         child.getName().c_str());
     }
-    addChildren(model, children[i]);
+    addChildren(model, child_it);
   }
 }
 
@@ -244,7 +242,7 @@ void RobotStatePublisher::publishTransforms(
 {
   RCLCPP_DEBUG(get_logger(), "Publishing transforms for moving joints");
 
-  std::string frame_prefix = get_parameter("frame_prefix").get_value<std::string>();
+  const std::string & frame_prefix = frame_prefix_;
 
   std::vector<geometry_msgs::msg::TransformStamped> tf_transforms;
 
@@ -268,7 +266,7 @@ void RobotStatePublisher::publishFixedTransforms()
 {
   RCLCPP_DEBUG(get_logger(), "Publishing transforms for fixed joints");
 
-  std::string frame_prefix = get_parameter("frame_prefix").get_value<std::string>();
+  const std::string & frame_prefix = frame_prefix_;
 
   std::vector<geometry_msgs::msg::TransformStamped> tf_transforms;
 
@@ -302,7 +300,7 @@ void RobotStatePublisher::callbackJointState(
   // check if we moved backwards in time (e.g. when playing a bag file)
   rclcpp::Time now = this->now();
   if (last_callback_time_.nanoseconds() > now.nanoseconds()) {
-    // force re-publish of joint ransforms
+    // force re-publish of joint transforms
     RCLCPP_WARN(
       get_logger(), "Moved backwards in time, re-publishing joint transforms!");
     last_publish_time_.clear();
@@ -311,8 +309,8 @@ void RobotStatePublisher::callbackJointState(
 
   // determine least recently published joint
   rclcpp::Time last_published = now;
-  for (size_t i = 0; i < state->name.size(); i++) {
-    rclcpp::Time t(last_publish_time_[state->name[i]]);
+  for (const std::string & name : state->name) {
+    rclcpp::Time t(last_publish_time_[name]);
     last_published = (t.nanoseconds() < last_published.nanoseconds()) ? t : last_published;
   }
   // note: if a joint was seen for the first time,
@@ -320,11 +318,10 @@ void RobotStatePublisher::callbackJointState(
 
   // check if we need to publish
   rclcpp::Time current_time(state->header.stamp);
-  double publish_freq = this->get_parameter("publish_frequency").get_value<double>();
   std::chrono::milliseconds publish_interval_ms =
-    std::chrono::milliseconds(static_cast<uint64_t>(1000.0 / publish_freq));
+    std::chrono::milliseconds(static_cast<uint64_t>(1000.0 / publish_frequency_));
   rclcpp::Time max_publish_time = last_published + rclcpp::Duration(publish_interval_ms);
-  if (get_parameter("ignore_timestamp").get_value<bool>() ||
+  if (ignore_timestamp_ ||
     current_time.nanoseconds() >= max_publish_time.nanoseconds())
   {
     // get joint positions from state message
@@ -344,8 +341,8 @@ void RobotStatePublisher::callbackJointState(
     publishTransforms(joint_positions, state->header.stamp);
 
     // store publish time in joint map
-    for (size_t i = 0; i < state->name.size(); i++) {
-      last_publish_time_[state->name[i]] = state->header.stamp;
+    for (const std::string & name : state->name) {
+      last_publish_time_[name] = state->header.stamp;
     }
   }
 }
@@ -378,9 +375,9 @@ rcl_interfaces::msg::SetParametersResult RobotStatePublisher::parameterUpdate(
       }
     } else if (parameter.get_name() == "publish_frequency") {
       double publish_freq = parameter.as_double();
-      if (publish_freq < 0.0 || publish_freq > 1000.0) {
+      if (publish_freq <= 0.0 || publish_freq > 1000.0) {
         result.successful = false;
-        result.reason = "publish_frequency must be between 0.0 and 1000.0";
+        result.reason = "publish_frequency must be between 0.0 (exclusive) and 1000.0";
         break;
       }
     }
@@ -397,17 +394,25 @@ void RobotStatePublisher::onParameterEvent(
     return;
   }
 
-  // Filter for 'robot_description' being changed.
-  rclcpp::ParameterEventsFilter filter(event, {"robot_description"},
+  // Filter for changed parameters that affect runtime behaviour.
+  rclcpp::ParameterEventsFilter filter(event,
+    {"robot_description", "publish_frequency", "frame_prefix", "ignore_timestamp"},
     {rclcpp::ParameterEventsFilter::EventType::CHANGED});
   for (auto & it : filter.get_events()) {
-    if (it.second->name == "robot_description") {
+    const std::string & name = it.second->name;
+    if (name == "robot_description") {
       try {
         setupURDF(it.second->value.string_value);
         publishFixedTransforms();
       } catch (const std::runtime_error & err) {
         RCLCPP_WARN(get_logger(), "Failed to parse new URDF: %s", err.what());
       }
+    } else if (name == "publish_frequency") {
+      publish_frequency_ = it.second->value.double_value;
+    } else if (name == "frame_prefix") {
+      frame_prefix_ = it.second->value.string_value;
+    } else if (name == "ignore_timestamp") {
+      ignore_timestamp_ = it.second->value.bool_value;
     }
   }
 }


### PR DESCRIPTION
 - publish_frequency = 0.0 now correctly rejected (division by zero)
 - cache publish_frequency, ignore_timestamp, as members — eliminates get_parameter calls on every joint state message
 - use `const KDL::SegmentMap &` to avoid an unnecessary map copy
 - replace index-based loops with range-for